### PR TITLE
 fix: UPDATE 구문 SET 절에서 PK 컬럼 제외

### DIFF
--- a/templates/code/sample-mapper-template.hbs
+++ b/templates/code/sample-mapper-template.hbs
@@ -33,12 +33,16 @@
 
 			UPDATE {{tableName}}
 			SET
+			{{~setVar "isFirstSet" true~}}
 			{{#each attributes}}
-				{{#if @first}}
+				{{#unless isPrimaryKey}}
+				{{#if @root.isFirstSet}}
 				{{columnName}}={{concat "#{" ccName "}"}}
+				{{~setVar "isFirstSet" false~}}
 				{{else}}
 				, {{columnName}}={{concat "#{" ccName "}"}}
 				{{/if}}
+				{{/unless}}
 			{{/each}}
 			WHERE
 			{{#if pkAttributes.length}}


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 버그 수정 (fix)

## 변경 내용 (Description)

`sample-mapper-template.hbs`의 UPDATE 구문이 SET 절에 PK 컬럼을 포함하여
잘못된 SQL을 생성하던 문제를 수정했습니다.

- **원인**: SET 절이 `{{#each attributes}}`로 모든 컬럼을 순회하기 때문에
  PK 컬럼까지 SET 절에 포함됩니다.
- **수정**: `{{#unless isPrimaryKey}}`로 PK 컬럼을 SET 절에서 제외했습니다.
- PK 컬럼은 변경 불가여야 하며, SET 절에 포함될 경우 Oracle 등에서
  런타임 오류가 발생할 수 있습니다. 단일 PK·복합 PK 모두 동일하게 적용됩니다.

**수정 전**

```xml
<update id="updateUser">
    UPDATE TB_USER
    SET
    USER_ID=#{userId},   <!-- PK가 SET에 포함 (잘못됨) -->
    USER_NM=#{userNm}
    WHERE USER_ID=#{userId}
</update>
```

**수정 후**

```xml
<update id="updateUser">
    UPDATE TB_USER
    SET
    USER_NM=#{userNm}    <!-- PK 제외됨 -->
    WHERE USER_ID=#{userId}
</update>
```

## 관련 이슈 (Related Issues)

- 

## 변경 영역 (Affected Areas)

- [x] CRUD 코드 생성 (Code Generation)
- [x] 템플릿 (`templates/`)

## 테스트 방법 (How Has This Been Tested?)

1. 아래 DDL로 코드를 생성합니다.

```sql
   CREATE TABLE TB_USER (
       USER_ID VARCHAR(20) NOT NULL,
       USER_NM VARCHAR(50),
       PRIMARY KEY (USER_ID)
   );
```

2. 생성된 매퍼의 UPDATE 구문 SET 절에 PK 컬럼(`USER_ID`)이 포함되지 않는지 확인합니다.
3. WHERE 절에는 PK 컬럼이 정상적으로 포함되는지 확인합니다.
4. 복합 PK 테이블에서도 모든 PK 컬럼이 SET 절에서 제외되는지 확인합니다.

## 스크린샷 (Screenshots)

UI 변경 없음 (N/A)

## 체크리스트 (Checklist)

- [ ] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [x] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [x] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [x] Extension Development Host(F5)에서 동작을 확인했습니다.
- [ ] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`@first` 대신 `isFirstSet` 플래그를 사용한 이유는, `@first`는 배열 인덱스 기준이라
PK가 첫 번째 컬럼인 경우 다음 non-PK 컬럼 앞에 콤마가 잘못 붙는 문제가 생기기 때문입니다.

**변경 파일**

- `templates/code/sample-mapper-template.hbs`