### PR TITLE
fix: TransactionForm READ_UNCOMMITTED 오타 수정

### DIFF
--- a/webview-ui/src/components/egov/forms/TransactionForm.tsx
+++ b/webview-ui/src/components/egov/forms/TransactionForm.tsx
@@ -688,7 +688,7 @@ const TransactionForm: React.FC<FormComponentProps> = ({ onSubmit, onCancel, tem
 									isRequired
 									options={[
 										{ value: "DEFAULT", label: "DEFAULT" },
-										{ value: "REQD_UNCOMMITTED", label: "READ_UNCOMMITTED" },
+										{ value: "READ_UNCOMMITTED", label: "READ_UNCOMMITTED" },
 										{ value: "READ_COMMITTED", label: "READ_COMMITTED" },
 										{ value: "REPEATABLE_READ", label: "REPEATABLE_READ" },
 										{ value: "SERIALIZABLE", label: "SERIALIZABLE" },


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일/UI 변경 (style)
- [ ] 테스트 추가/수정 (test)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
`TransactionForm.tsx`의 트랜잭션 격리 수준 옵션에서 `READ_UNCOMMITTED`가 `REQD_UNCOMMITTED`로 잘못 표기된 오타를 수정했습니다.
  - **원인**: Isolation Level 선택 옵션의 value 문자열 오타
  - **수정**: `REQD_UNCOMMITTED`를 `READ_UNCOMMITTED`로 변경

## 관련 이슈 (Related Issues)

## 변경 영역 (Affected Areas)
- [ ] 프로젝트 생성 (Project Generation)
- [ ] CRUD 코드 생성 (Code Generation)
- [ ] 설정 파일 생성 (Config Generation)
- [ ] Extension 코어 (`src/core`)
- [x] Webview UI (`webview-ui`)
- [ ] 템플릿 (`templates/`)
- [ ] 문서 / 기타

## 테스트 방법 (How Has This Been Tested?)
  1. Extension Development Host(F5)로 확장 실행
  2. Configuration 탭에서 Transaction 설정 폼 진입
  3. Isolation Level 옵션에 `READ_UNCOMMITTED`가 정상 표시되는지 확인
  4. Transaction 설정 파일 생성 시 `READ_UNCOMMITTED` 값이 정상 반영되는지 확인

## 스크린샷 (Screenshots)
UI에는 오타 없는 글자로 들어가 있었기에 UI는 변경 없음

## 체크리스트 (Checklist)

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [x] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [x] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [x] Extension Development Host(F5)에서 동작을 확인했습니다.
- [x] Webview 변경이 있는 경우 `cd webview-ui && npm run test` 를 통과했습니다.
- [x] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.
- [x] 필요한 경우 관련 문서(README, CONTRIBUTING, CLAUDE.md 등)를 업데이트했습니다.

## 추가 참고 사항 (Additional Notes)
- 단순 문자열 오타 수정으로 별도 문서 변경은 없습니다.