### PR TITLE
feat: DDL 기반 ERD 미리보기 기능 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Code Generation
+  - DDL 입력 내용을 기반으로 테이블, 컬럼, PK/FK, 1:N 관계를 표시하는 ERD Preview 추가
+
 ## v5.0.0 Beta (2025-12-04)
 
 - v5.0.x Initial Beta Release

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - **DDL 문법 검증**: `monaco-sql-languages` 라이브러리를 통한 실시간 SQL 문법 검증 및 오류 표시
 - **11개 템플릿 미리보기**: VO, DefaultVO, Controller, Service, ServiceImpl, Mapper, Mapper Interface, JSP List/Register, Thymeleaf List/Register
 - **미리보기 선택적 자동 업데이트**: 사용자가 원할 때만 자동 미리보기 생성
+- **ERD 미리보기**: 입력된 `CREATE TABLE` DDL을 테이블/컬럼/PK/FK 관계 다이어그램으로 시각화
 - **병렬 렌더링**: 11개 템플릿을 동시에 처리하여 빠른 미리보기 생성
 - **Handlebars 바인딩**: 실제 데이터가 바인딩된 완성된 코드 미리보기
 
@@ -53,7 +54,8 @@
 3. **미리보기 생성**: "미리보기 생성" 버튼 클릭
 4. **템플릿 선택**: 드롭다운에서 원하는 템플릿 선택
 5. **코드 확인**: 실제 바인딩된 코드 미리보기
-6. **자동 업데이트**: 체크박스로 DDL 변경시 자동 미리보기 업데이트 설정
+6. **ERD 확인**: 유효한 DDL이면 Code Generator 화면에서 ERD Preview 확인
+7. **자동 업데이트**: 체크박스로 DDL 변경시 자동 미리보기 업데이트 설정
 
 ##### 성능 최적화
 - **지연 로딩**: 필요시에만 미리보기 생성 (기본 동작)
@@ -88,13 +90,22 @@ CREATE TABLE users (
   email VARCHAR(100) UNIQUE NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE orders (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  user_id INT NOT NULL,
+  total_amount DECIMAL(10, 2) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(id)
+);
 ```
 
 #### 2. 미리보기 생성
 1. DDL 입력 후 500ms 디바운스로 유효성 검사 완료
-2. "미리보기 생성" 버튼 클릭
-3. 드롭다운에서 원하는 템플릿 선택 (예: VO, Controller, Service 등)
-4. 실제 바인딩된 코드 미리보기 확인
+2. Code Generator 화면의 "ERD Preview"에서 테이블과 FK 관계 다이어그램 확인
+3. "미리보기 생성" 버튼 클릭
+4. 드롭다운에서 원하는 템플릿 선택 (예: VO, Controller, Service 등)
+5. 실제 바인딩된 코드 미리보기 확인
 
 #### 3. 자동 업데이트 설정
 - "DDL 변경시 자동으로 미리보기 업데이트" 체크박스 활성화

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@
 │  │   └── ...                       │  │   │   ├── CodePreview.tsx        │
 │  ├── shared/                       │  │   │   ├── EgovSettingsView.tsx   │
 │  │   ├── dataTypes.ts              │  │   │   ├── EgovView.tsx           │
+│  │   ├── erdParser.ts              │  │   │   ├── ErdDiagram.tsx         │
 │  │   ├── ExtensionMessage.ts       │  │   ├── ui/                        │
 │  │   ├── WebviewMessage.ts         │  ├── context/                       │
 │  │   └── ...                       │  ├── shared/                        │
@@ -89,6 +90,7 @@ src/
 │   ├── AutoApprovalSettings.ts          # 자동 승인 설정 타입
 │   ├── dataTypes.ts                     # DB 타입 -> Java 타입 매핑
 │   ├── ddlParser.ts                     # DDL 검증 및 파싱
+│   ├── erdParser.ts                     # ERD Preview용 테이블/관계 파싱
 │   ├── ExtensionMessage.ts              # Extension -> Webview 메시지 타입
 │   ├── templateContext.ts               # CRUD 템플릿 컨텍스트 생성
 │   └── WebviewMessage.ts                # Webview -> Extension 메시지 타입
@@ -214,6 +216,7 @@ webview-ui/
     │   │   ├── types/               # types 설정 인터페이스
     │   │   │   └── templates.ts     # ConfigFormData 인터페이스
     │   │   ├── CodePreview.tsx      # 코드 생성 탭 내 프리뷰 화면
+    │   │   ├── ErdDiagram.tsx       # DDL 기반 ERD Preview 화면
     │   │   └── EgovSettingsView.tsx # Extension 설정 화면
     ├── context/
     │   ├── EgovTabsStateContext.tsx # egov 탭 상태 관리

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -16,6 +16,12 @@ export interface ParsedDDL {
 	pkAttributes: Column[]
 }
 
+export interface CreateTableStatement {
+	tableName: string
+	body: string
+	statement: string
+}
+
 // snake_case를 camelCase로 변환하는 함수
 function convertToCamelCase(str: string): string {
 	return str.toLowerCase().replace(/_([a-z])/g, (match, letter) => letter.toUpperCase())
@@ -29,26 +35,54 @@ function convertCamelcaseToPascalcase(name: string): string {
 	return name.charAt(0).toUpperCase() + name.slice(1)
 }
 
+export function extractCreateTableStatements(ddl: string): CreateTableStatement[] {
+	const statements: CreateTableStatement[] = []
+	const createTableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?\s*\(/gi
+	let match: RegExpExecArray | null
+
+	while ((match = createTableRegex.exec(ddl)) !== null) {
+		const bodyStart = createTableRegex.lastIndex
+		let depth = 1
+		let currentIndex = bodyStart
+
+		while (currentIndex < ddl.length && depth > 0) {
+			const char = ddl[currentIndex]
+			if (char === "(") {
+				depth += 1
+			} else if (char === ")") {
+				depth -= 1
+			}
+			currentIndex += 1
+		}
+
+		if (depth === 0) {
+			const bodyEnd = currentIndex - 1
+			statements.push({
+				tableName: match[1],
+				body: ddl.slice(bodyStart, bodyEnd),
+				statement: ddl.slice(match.index, currentIndex),
+			})
+			createTableRegex.lastIndex = currentIndex
+		}
+	}
+
+	return statements
+}
+
 // DDL 파싱 함수
 export function parseDDL(ddl: string): ParsedDDL {
 	// 공백 정규화
-	ddl = ddl.replace(/\s+/g, " ").trim()
+	const normalizedDdl = ddl.replace(/\s+/g, " ").trim()
+	const createTableStatement = extractCreateTableStatements(normalizedDdl)[0]
 
 	// 테이블 이름 추출 (백틱 처리 추가) - DDL 시작 부분에서만 매칭
-	const tableNameMatch = RegExp(/^\s*CREATE\s+TABLE\s+[`]?(\w+)[`]?/i).exec(ddl)
-	if (!tableNameMatch) {
+	if (!createTableStatement) {
 		throw new Error("Unable to parse table name from DDL")
 	}
-	const tableName = convertCamelcaseToPascalcase(convertToCamelCase(tableNameMatch[1]))
+	const tableName = convertCamelcaseToPascalcase(convertToCamelCase(createTableStatement.tableName))
 
 	// 컬럼 정의 추출
-	const columnDefinitionsMatch = RegExp(/\((.*)\)/s).exec(ddl)
-	if (!columnDefinitionsMatch) {
-		throw new Error("Unable to parse column definitions from DDL")
-	}
-
-	// 컬럼 정의를 개별 컬럼으로 분리
-	const columnDefinitions = columnDefinitionsMatch[1]
+	const columnDefinitions = createTableStatement.body
 	const columnsArray = columnDefinitions
 		.split(/,(?![^(]*\))/)
 		.map((column) => column.trim())
@@ -65,7 +99,7 @@ export function parseDDL(ddl: string): ParsedDDL {
 	const pkAttributes: Column[] = []
 
 	// PRIMARY KEY 제약조건 찾기
-	const pkConstraintMatch = RegExp(/PRIMARY KEY\s*\(([^)]+)\)/i).exec(ddl)
+	const pkConstraintMatch = RegExp(/PRIMARY KEY\s*\(([^)]+)\)/i).exec(createTableStatement.statement)
 	const primaryKeyColumns = pkConstraintMatch
 		? pkConstraintMatch[1].split(",").map((col) => col.trim().replace(/[`"']/g, ""))
 		: []
@@ -136,14 +170,14 @@ export function validateDDL(ddl: string): boolean {
 		return false
 	}
 
-	// CREATE TABLE 테이블명 ( ... ) 형식 확인 - 테이블명 뒤에 괄호가 있어야 함
-	if (!/CREATE\s+TABLE\s+[^\s(]+\s*\(/i.test(ddl)) {
+	const createTableStatement = extractCreateTableStatements(ddl)[0]
+	if (!createTableStatement) {
 		return false
 	}
 
 	// 괄호 쌍 확인
-	const openParens = (ddl.match(/\(/g) || []).length
-	const closeParens = (ddl.match(/\)/g) || []).length
+	const openParens = (createTableStatement.statement.match(/\(/g) || []).length
+	const closeParens = (createTableStatement.statement.match(/\)/g) || []).length
 
 	// 괄호 개수가 맞지 않으면 유효하지 않음
 	if (openParens !== closeParens) {
@@ -151,14 +185,12 @@ export function validateDDL(ddl: string): boolean {
 	}
 
 	// 최소한의 컬럼 정의 확인
-	const columnRegex = /\((.*)\)/s
-	const columnMatch = columnRegex.exec(ddl)
-	if (!columnMatch?.[1]?.trim()) {
+	if (!createTableStatement.body.trim()) {
 		return false
 	}
 
 	// 각 컬럼 정의 검증
-	const columnDefinitions = columnMatch[1]
+	const columnDefinitions = createTableStatement.body
 	const columnsArray = columnDefinitions
 		.split(/,(?![^(]*\))/)
 		.map((column) => column.trim())

--- a/src/shared/erdParser.ts
+++ b/src/shared/erdParser.ts
@@ -1,0 +1,125 @@
+import { extractCreateTableStatements } from "./ddlParser"
+
+export interface ErdColumn {
+	name: string
+	dataType: string
+	isPrimaryKey: boolean
+	isForeignKey: boolean
+}
+
+export interface ErdTable {
+	name: string
+	columns: ErdColumn[]
+}
+
+export interface ErdRelationship {
+	fromTable: string
+	fromColumn: string
+	toTable: string
+	toColumn: string
+}
+
+export interface ErdModel {
+	tables: ErdTable[]
+	relationships: ErdRelationship[]
+}
+
+function cleanIdentifier(identifier: string): string {
+	return identifier.trim().replace(/^[`"']|[`"']$/g, "")
+}
+
+function splitColumnDefinitions(body: string): string[] {
+	return body
+		.split(/,(?![^(]*\))/)
+		.map((definition) => definition.trim())
+		.filter(Boolean)
+}
+
+function parseColumnList(columnList: string): string[] {
+	return columnList.split(",").map(cleanIdentifier).filter(Boolean)
+}
+
+function getDefinitionKind(definition: string): string {
+	return definition.split(/\s+/)[0]?.toUpperCase() || ""
+}
+
+export function parseErdModel(ddl: string): ErdModel {
+	const createTableStatements = extractCreateTableStatements(ddl)
+	const tables: ErdTable[] = []
+	const relationships: ErdRelationship[] = []
+
+	for (const createTableStatement of createTableStatements) {
+		const tableName = cleanIdentifier(createTableStatement.tableName)
+		const definitions = splitColumnDefinitions(createTableStatement.body)
+		const primaryKeyColumns = new Set<string>()
+		const foreignKeyColumns = new Set<string>()
+		const columns: ErdColumn[] = []
+
+		for (const definition of definitions) {
+			const pkMatch = /PRIMARY\s+KEY\s*\(([^)]+)\)/i.exec(definition)
+			if (pkMatch) {
+				parseColumnList(pkMatch[1]).forEach((columnName) => primaryKeyColumns.add(columnName))
+				continue
+			}
+
+			const fkMatch = /FOREIGN\s+KEY\s*\(([^)]+)\)\s+REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(definition)
+			if (fkMatch) {
+				const fromColumns = parseColumnList(fkMatch[1])
+				const toTable = cleanIdentifier(fkMatch[2])
+				const toColumns = parseColumnList(fkMatch[3])
+
+				fromColumns.forEach((fromColumn, index) => {
+					foreignKeyColumns.add(fromColumn)
+					relationships.push({
+						fromTable: tableName,
+						fromColumn,
+						toTable,
+						toColumn: toColumns[index] || toColumns[0] || "id",
+					})
+				})
+				continue
+			}
+		}
+
+		for (const definition of definitions) {
+			const definitionKind = getDefinitionKind(definition)
+			if (["PRIMARY", "FOREIGN", "CONSTRAINT", "UNIQUE", "KEY", "INDEX", "COMMENT"].includes(definitionKind)) {
+				continue
+			}
+
+			const parts = definition.split(/\s+/).filter(Boolean)
+			const columnName = cleanIdentifier(parts[0] || "")
+			const dataType = (parts[1] || "").toUpperCase()
+
+			if (!columnName || !dataType) {
+				continue
+			}
+
+			const inlineReferenceMatch = /REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(definition)
+			if (inlineReferenceMatch) {
+				const toTable = cleanIdentifier(inlineReferenceMatch[1])
+				const toColumn = parseColumnList(inlineReferenceMatch[2])[0] || "id"
+				foreignKeyColumns.add(columnName)
+				relationships.push({
+					fromTable: tableName,
+					fromColumn: columnName,
+					toTable,
+					toColumn,
+				})
+			}
+
+			columns.push({
+				name: columnName,
+				dataType,
+				isPrimaryKey: primaryKeyColumns.has(columnName) || /\bPRIMARY\s+KEY\b/i.test(definition),
+				isForeignKey: foreignKeyColumns.has(columnName),
+			})
+		}
+
+		if (columns.length > 0) {
+			tables.push({ name: tableName, columns })
+		}
+	}
+
+	return { tables, relationships }
+}

--- a/webview-ui/src/components/egov/ErdDiagram.tsx
+++ b/webview-ui/src/components/egov/ErdDiagram.tsx
@@ -1,0 +1,282 @@
+import React from "react"
+import type { ErdModel } from "@shared/erdParser"
+
+interface ErdDiagramProps {
+	model: ErdModel | null
+}
+
+const tableWidth = 260
+const tableGapX = 70
+const tableGapY = 42
+const headerHeight = 36
+const columnHeight = 28
+const relationPadding = 8
+
+function getRelationPoints(
+	from: { x: number; y: number; height: number },
+	to: { x: number; y: number; height: number },
+): {
+	startX: number
+	startY: number
+	endX: number
+	endY: number
+	startLabelX: number
+	startLabelY: number
+	endLabelX: number
+	endLabelY: number
+	controlX1: number
+	controlY1: number
+	controlX2: number
+	controlY2: number
+} {
+	const fromCenterX = from.x + tableWidth / 2
+	const fromCenterY = from.y + from.height / 2
+	const toCenterX = to.x + tableWidth / 2
+	const toCenterY = to.y + to.height / 2
+	const horizontalDistance = Math.abs(toCenterX - fromCenterX)
+	const verticalDistance = Math.abs(toCenterY - fromCenterY)
+
+	if (horizontalDistance >= verticalDistance) {
+		const fromIsLeft = fromCenterX <= toCenterX
+		const startX = fromIsLeft ? from.x + tableWidth : from.x
+		const endX = fromIsLeft ? to.x : to.x + tableWidth
+		const startY = fromCenterY
+		const endY = toCenterY
+		const controlOffset = Math.max(44, horizontalDistance / 2)
+		const direction = fromIsLeft ? 1 : -1
+
+		return {
+			startX,
+			startY,
+			endX,
+			endY,
+			startLabelX: startX + direction * relationPadding,
+			startLabelY: startY - relationPadding,
+			endLabelX: endX - direction * (relationPadding + 4),
+			endLabelY: endY - relationPadding,
+			controlX1: startX + direction * controlOffset,
+			controlY1: startY,
+			controlX2: endX - direction * controlOffset,
+			controlY2: endY,
+		}
+	}
+
+	const fromIsAbove = fromCenterY <= toCenterY
+	const startX = fromCenterX
+	const endX = toCenterX
+	const startY = fromIsAbove ? from.y + from.height : from.y
+	const endY = fromIsAbove ? to.y : to.y + to.height
+	const controlOffset = Math.max(34, verticalDistance / 2)
+	const direction = fromIsAbove ? 1 : -1
+
+	return {
+		startX,
+		startY,
+		endX,
+		endY,
+		startLabelX: startX + relationPadding,
+		startLabelY: startY + direction * 18,
+		endLabelX: endX + relationPadding,
+		endLabelY: endY - direction * relationPadding,
+		controlX1: startX,
+		controlY1: startY + direction * controlOffset,
+		controlX2: endX,
+		controlY2: endY - direction * controlOffset,
+	}
+}
+
+const ErdDiagram: React.FC<ErdDiagramProps> = ({ model }) => {
+	if (!model || model.tables.length === 0) {
+		return null
+	}
+
+	const columnsPerRow = Math.min(3, Math.max(1, model.tables.length))
+	const tableHeights = model.tables.map((table) => headerHeight + table.columns.length * columnHeight)
+	const rowHeights = Array.from({ length: Math.ceil(model.tables.length / columnsPerRow) }, (_, rowIndex) =>
+		Math.max(...tableHeights.slice(rowIndex * columnsPerRow, rowIndex * columnsPerRow + columnsPerRow)),
+	)
+	const positions = model.tables.reduce<Record<string, { x: number; y: number; height: number }>>((acc, table, index) => {
+		const row = Math.floor(index / columnsPerRow)
+		const column = index % columnsPerRow
+		const height = tableHeights[index]
+		const y = rowHeights.slice(0, row).reduce((sum, rowHeight) => sum + rowHeight + tableGapY, 0)
+
+		acc[table.name] = {
+			x: column * (tableWidth + tableGapX),
+			y,
+			height,
+		}
+		return acc
+	}, {})
+
+	const maxRows = Math.ceil(model.tables.length / columnsPerRow)
+	const diagramWidth = columnsPerRow * tableWidth + (columnsPerRow - 1) * tableGapX
+	const diagramHeight =
+		maxRows === 0
+			? 0
+			: Math.max(
+					...model.tables.map((table) => {
+						const position = positions[table.name]
+						return position.y + position.height
+					}),
+				)
+
+	return (
+		<div style={{ marginBottom: "20px" }}>
+			<h4 style={{ color: "var(--vscode-foreground)", marginBottom: "10px" }}>ERD Preview</h4>
+			<div
+				style={{
+					backgroundColor: "var(--vscode-editor-inactiveSelectionBackground)",
+					border: "1px solid var(--vscode-settings-textInputBorder)",
+					borderRadius: "4px",
+					overflowX: "auto",
+					padding: "14px",
+				}}>
+				<div style={{ position: "relative", width: diagramWidth, minHeight: diagramHeight }}>
+					<svg
+						width={diagramWidth}
+						height={diagramHeight}
+						style={{
+							position: "absolute",
+							left: 0,
+							top: 0,
+							pointerEvents: "none",
+						}}>
+						<defs>
+							<marker
+								id="erd-arrow"
+								markerWidth="10"
+								markerHeight="10"
+								refX="9"
+								refY="3"
+								orient="auto"
+								markerUnits="strokeWidth">
+								<path d="M0,0 L0,6 L9,3 z" fill="currentColor" />
+							</marker>
+						</defs>
+						{model.relationships.map((relationship, index) => {
+							const from = positions[relationship.fromTable]
+							const to = positions[relationship.toTable]
+							if (!from || !to) {
+								return null
+							}
+
+							const relationPoints = getRelationPoints(from, to)
+
+							return (
+								<g
+									key={`${relationship.fromTable}-${relationship.fromColumn}-${relationship.toTable}-${relationship.toColumn}-${index}`}
+									style={{ color: "var(--vscode-charts-blue)" }}>
+									<path
+										d={`M ${relationPoints.startX} ${relationPoints.startY} C ${relationPoints.controlX1} ${relationPoints.controlY1}, ${relationPoints.controlX2} ${relationPoints.controlY2}, ${relationPoints.endX} ${relationPoints.endY}`}
+										stroke="currentColor"
+										strokeWidth="1.7"
+										fill="none"
+										markerEnd="url(#erd-arrow)"
+									/>
+									<text
+										x={relationPoints.startLabelX}
+										y={relationPoints.startLabelY}
+										fill="currentColor"
+										fontSize="11"
+										fontWeight="700">
+										N
+									</text>
+									<text
+										x={relationPoints.endLabelX}
+										y={relationPoints.endLabelY}
+										fill="currentColor"
+										fontSize="11"
+										fontWeight="700">
+										1
+									</text>
+								</g>
+							)
+						})}
+					</svg>
+
+					{model.tables.map((table) => {
+						const position = positions[table.name]
+						return (
+							<div
+								key={table.name}
+								style={{
+									position: "absolute",
+									left: position.x,
+									top: position.y,
+									width: tableWidth,
+									backgroundColor: "var(--vscode-editor-background)",
+									border: "1px solid var(--vscode-panel-border)",
+									borderRadius: "4px",
+									overflow: "hidden",
+									boxShadow: "0 1px 3px rgba(0, 0, 0, 0.18)",
+								}}>
+								<div
+									style={{
+										height: headerHeight,
+										display: "flex",
+										alignItems: "center",
+										padding: "0 10px",
+										backgroundColor: "var(--vscode-sideBarSectionHeader-background)",
+										borderBottom: "1px solid var(--vscode-panel-border)",
+										color: "var(--vscode-foreground)",
+										fontSize: "13px",
+										fontWeight: 700,
+									}}>
+									{table.name}
+								</div>
+								{table.columns.map((column) => (
+									<div
+										key={column.name}
+										style={{
+											height: columnHeight,
+											display: "grid",
+											gridTemplateColumns: "auto 1fr auto",
+											alignItems: "center",
+											gap: "7px",
+											padding: "0 10px",
+											borderBottom: "1px solid var(--vscode-panel-border)",
+											color: "var(--vscode-foreground)",
+											fontSize: "12px",
+										}}>
+										<span
+											style={{
+												minWidth: "22px",
+												color: column.isPrimaryKey
+													? "var(--vscode-terminal-ansiYellow)"
+													: column.isForeignKey
+														? "var(--vscode-charts-blue)"
+														: "var(--vscode-descriptionForeground)",
+												fontSize: "10px",
+												fontWeight: 700,
+											}}>
+											{column.isPrimaryKey ? "PK" : column.isForeignKey ? "FK" : ""}
+										</span>
+										<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+											{column.name}
+										</span>
+										<span style={{ color: "var(--vscode-descriptionForeground)", fontSize: "11px" }}>
+											{column.dataType}
+										</span>
+									</div>
+								))}
+							</div>
+						)
+					})}
+				</div>
+				{model.relationships.length === 0 && (
+					<div
+						style={{
+							marginTop: "12px",
+							color: "var(--vscode-descriptionForeground)",
+							fontSize: "12px",
+						}}>
+						No foreign key relationships found.
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export default ErdDiagram

--- a/webview-ui/src/components/egov/tabs/CodeView.tsx
+++ b/webview-ui/src/components/egov/tabs/CodeView.tsx
@@ -1,7 +1,8 @@
 import { Button, TextArea, Link, ProgressRing, TextField } from "../../ui"
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { parseDDL, validateDDL, ParsedDDL } from "@shared/ddlParser"
+import { parseErdModel } from "@shared/erdParser"
 import { getTemplateContext } from "@shared/templateContext"
 import { WebviewMessage, ExtensionResponse } from "../../../utils/messageTypes"
 import { createSelectOutputPathMessage } from "../../../utils/egovUtils"
@@ -9,6 +10,7 @@ import { vscode } from "../../../utils/vscode"
 import { validateCodeConfig, type CodeConfig } from "../../../utils/codeUtils"
 import { useCodeViewState } from "../../../context/EgovTabsStateContext"
 import CodePreview from "../CodePreview"
+import ErdDiagram from "../ErdDiagram"
 import Editor, { loader } from "@monaco-editor/react"
 import * as monaco from "monaco-editor"
 
@@ -83,6 +85,18 @@ const CodeView = () => {
 	const monacoRef = useRef<typeof monaco | null>(null)
 	// DDL 검증 디바운스 타이머
 	const ddlValidationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+	const erdModel = useMemo(() => {
+		if (!isValid || !ddlContent.trim()) {
+			return null
+		}
+
+		try {
+			return parseErdModel(ddlContent)
+		} catch (error) {
+			console.warn("ERD parsing failed:", error)
+			return null
+		}
+	}, [ddlContent, isValid])
 
 	// Helper functions to update state
 	const setDdlContent = (value: string) => updateState({ ddlContent: value })
@@ -841,6 +855,9 @@ const CodeView = () => {
 						</div>
 					)}
 				</div>
+
+				{/* ERD Preview */}
+				<ErdDiagram model={erdModel} />
 
 				{/* Parsed DDL Preview */}
 				{parsedDDL && (

--- a/webview-ui/src/utils/__tests__/erdParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/erdParser.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { parseErdModel } from "@shared/erdParser"
+
+describe("parseErdModel", () => {
+	it("parses tables and table-level foreign key relationships", () => {
+		const model = parseErdModel(`
+			CREATE TABLE users (
+				id INT PRIMARY KEY AUTO_INCREMENT,
+				name VARCHAR(100) NOT NULL
+			);
+
+			CREATE TABLE orders (
+				id INT PRIMARY KEY AUTO_INCREMENT,
+				user_id INT NOT NULL,
+				CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(id)
+			);
+		`)
+
+		expect(model.tables).toHaveLength(2)
+		expect(model.tables[0].columns.find((column) => column.name === "id")?.isPrimaryKey).toBe(true)
+		expect(model.tables[1].columns.find((column) => column.name === "user_id")?.isForeignKey).toBe(true)
+		expect(model.relationships).toEqual([
+			{
+				fromTable: "orders",
+				fromColumn: "user_id",
+				toTable: "users",
+				toColumn: "id",
+			},
+		])
+	})
+
+	it("parses inline foreign key references", () => {
+		const model = parseErdModel(`
+			CREATE TABLE users (
+				id INT PRIMARY KEY
+			);
+
+			CREATE TABLE comments (
+				id INT PRIMARY KEY,
+				user_id INT REFERENCES users(id)
+			);
+		`)
+
+		expect(model.relationships).toEqual([
+			{
+				fromTable: "comments",
+				fromColumn: "user_id",
+				toTable: "users",
+				toColumn: "id",
+			},
+		])
+	})
+})


### PR DESCRIPTION
<!--
PR 제목은 Conventional Commits 규칙을 따라주세요.
예) feat: CRUD 코드 생성에 Thymeleaf 템플릿 추가
    fix: DDL 파서가 PostgreSQL 스키마를 인식하지 못하는 문제 수정
-->

## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [x] 신규 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 스타일/UI 변경 (style)
- [x] 테스트 추가/수정 (test)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->
CRUD 코드 생성 화면에서 사용자가 입력한 DDL을 기반으로 ERD Preview를 확인할 수 있도록 기능을 추가했습니다.
유효한 `CREATE TABLE` DDL이 입력되면 테이블, 컬럼, PK/FK 정보를 파싱하고, FK 관계를 ERD 형태의 다이어그램으로 표시합니다.
관계선에는 FK를 가진 테이블 쪽을 `N`, 참조 대상 테이블 쪽을 `1`로 표시하여 1:N 관계를 확인할 수 있도록 했습니다.

기존 CRUD 코드 생성 흐름은 유지하면서, Code Generator 화면에서 DDL 구조와 테이블 관계를 코드 생성 전에 시각적으로 확인할 수 있도록 개선했습니다.


## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

- 

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 프로젝트 생성 (Project Generation)
- [x] CRUD 코드 생성 (Code Generation)
- [ ] 설정 파일 생성 (Config Generation)
- [ ] Extension 코어 (`src/core`)
- [x] Webview UI (`webview-ui`)
- [ ] 템플릿 (`templates/`)
- [x] 문서 / 기타

## 테스트 방법 (How Has This Been Tested?)

<!-- 변경 사항을 어떻게 확인했는지 재현 가능한 절차로 작성해주세요. -->

  1. `npm run check-types` 실행
  2. `npm run lint` 실행
  3. `npm run format` 실행
  4. `cd webview-ui && npm run test` 실행
  5. `npm run package` 실행
  6. Extension Development Host(F5)에서 Code Generator 화면 진입
  7. FK 관계가 포함된 DDL을 입력한 뒤 ERD Preview에서 테이블, 컬럼, PK/FK, 1:N 관계 표시 확인

예시 DDL
CREATE TABLE users (
    id INT PRIMARY KEY AUTO_INCREMENT,
    name VARCHAR(100) NOT NULL,
    email VARCHAR(100) UNIQUE NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
  );

  CREATE TABLE categories (
    id INT PRIMARY KEY AUTO_INCREMENT,
    name VARCHAR(100) NOT NULL
  );

  CREATE TABLE products (
    id INT PRIMARY KEY AUTO_INCREMENT,
    category_id INT NOT NULL,
    name VARCHAR(150) NOT NULL,
    price DECIMAL(10, 2) NOT NULL,
    CONSTRAINT fk_products_category FOREIGN KEY (category_id) REFERENCES categories(id)
  );

  CREATE TABLE orders (
    id INT PRIMARY KEY AUTO_INCREMENT,
    user_id INT NOT NULL,
    order_status VARCHAR(30) NOT NULL,
    total_amount DECIMAL(10, 2) NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(id)
  );

  CREATE TABLE order_items (
    id INT PRIMARY KEY AUTO_INCREMENT,
    order_id INT NOT NULL,
    product_id INT NOT NULL,
    quantity INT NOT NULL,
    unit_price DECIMAL(10, 2) NOT NULL,
    CONSTRAINT fk_order_items_order FOREIGN KEY (order_id) REFERENCES orders(id),
    CONSTRAINT fk_order_items_product FOREIGN KEY (product_id) REFERENCES products(id)
  );

## 스크린샷 (Screenshots)

<!-- UI 변경이 있다면 변경 전/후 스크린샷 또는 GIF를 첨부해주세요. -->

<img width="1170" height="1037" alt="ERD_PREVIEW" src="https://github.com/user-attachments/assets/41a1246e-3cf9-40d7-8659-bd6660b4b99b" />


## 체크리스트 (Checklist)

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [x] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [x] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [x] Extension Development Host(F5)에서 동작을 확인했습니다.
- [x] Webview 변경이 있는 경우 `cd webview-ui && npm run test` 를 통과했습니다.
- [x] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.
- [x] 필요한 경우 관련 문서(README, CONTRIBUTING, CLAUDE.md 등)를 업데이트했습니다.

## 추가 참고 사항 (Additional Notes)
 - ERD Preview는 입력된 DDL에서 `CREATE TABLE`, `PRIMARY KEY`, `FOREIGN KEY`, `REFERENCES` 구문을 기반으로 관계를 표시합니다.
  - CRUD 코드 생성용 기존 DDL 파싱 흐름은 유지하고, ERD Preview용 파서를 별도로 추가했습니다.

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->


