### PR TITLE
fix: AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정

### DIFF
--- a/templates/config/transaction/datasource-java.hbs
+++ b/templates/config/transaction/datasource-java.hbs
@@ -94,10 +94,10 @@ public class {{txtFileName}} {
 
     // TransactionAdvisor 설정
     @Bean
-    public Advisor txAdvisor(@Qualifier("{{txtTransactionName}}") DataSourceTransactionManager txManager) {
+    public Advisor txAdvisor(@Qualifier("{{txtAdviceName}}") TransactionInterceptor txAdvice) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression("{{txtPointCutExpression}}");
-        return new DefaultPointcutAdvisor(pointcut, txAdvice(txManager));
+        return new DefaultPointcutAdvisor(pointcut, txAdvice);
     }
     {{/if}}
 }

--- a/templates/config/transaction/jpa-java.hbs
+++ b/templates/config/transaction/jpa-java.hbs
@@ -123,10 +123,10 @@ public class {{txtFileName}} {
 
     // TransactionAdvisor 설정
     @Bean
-    public Advisor txAdvisor(@Qualifier("{{txtTransactionName}}") PlatformTransactionManager txManager) {
+    public Advisor txAdvisor(@Qualifier("{{txtAdviceName}}") TransactionInterceptor txAdvice) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression("{{txtPointCutExpression}}");
-        return new DefaultPointcutAdvisor(pointcut, txAdvice(txManager));
+        return new DefaultPointcutAdvisor(pointcut, txAdvice);
     }
     {{/if}}
 

--- a/templates/config/transaction/jta-java.hbs
+++ b/templates/config/transaction/jta-java.hbs
@@ -21,6 +21,7 @@ import org.springframework.transaction.interceptor.NoRollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
 import com.atomikos.icatch.jta.UserTransactionImp;

--- a/templates/config/transaction/jta-java.hbs
+++ b/templates/config/transaction/jta-java.hbs
@@ -110,10 +110,10 @@ public class {{txtFileName}} {
 
     // TransactionAdvisor 설정
     @Bean
-    public Advisor txAdvisor(PlatformTransactionManager txManager) {
+    public Advisor txAdvisor(@Qualifier("{{txtAdviceName}}") TransactionInterceptor txAdvice) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression("{{txtPointCutExpression}}");
-        return new DefaultPointcutAdvisor(pointcut, txAdvice(txManager));
+        return new DefaultPointcutAdvisor(pointcut, txAdvice);
     }
     {{/if}}
 }


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일/UI 변경 (style)
- [ ] 테스트 추가/수정 (test)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`@Configuration(proxyBeanMethods = false)` 환경에서 CGLIB 프록시가 동작하지 않아, `txAdvice(txManager)` 호출이 Spring 컨텍스트와 무관한 새로운 인스턴스를 생성하는 문제가 있었습니다. 그 결과 `txAdvisor`가 참조하는 `txAdvice`와 Spring이 관리하는 `txAdvice` 빈이 서로 다른 인스턴스기 때문에 트랜잭션이 올바르게 적용되지 않을 수 있습니다.

따라서 AOP 기반 트랜잭션 설정(`chkAopConfigTransaction`)으로 Java Config 파일을 생성할 때, `txAdvisor`가 `txAdvice`를 직접 호출하는 대신 파라미터를 주입하는 방식으로 변경했습니다.

```java
// 수정 전
@Bean
public Advisor txAdvisor(@Qualifier("txManager") DataSourceTransactionManager txManager) {
    ...
    return new DefaultPointcutAdvisor(pointcut, txAdvice(txManager)); // 직접 호출
}

// 수정 후
@Bean
public Advisor txAdvisor(@Qualifier("txAdvice") TransactionInterceptor txAdvice) {
    ...
    return new DefaultPointcutAdvisor(pointcut, txAdvice); // 파라미터 주입
}
```


## 관련 이슈 (Related Issues)

Closes #11 


## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 프로젝트 생성 (Project Generation)
- [ ] CRUD 코드 생성 (Code Generation)
- [x] 설정 파일 생성 (Config Generation)
- [ ] Extension 코어 (`src/core`)
- [ ] Webview UI (`webview-ui`)
- [x] 템플릿 (`templates/`)
- [ ] 문서 / 기타

## 테스트 방법 (How Has This Been Tested?)

Spring Boot 3.5.14 프로젝트에서 수정 전과 수정 후 동작을 검증했습니다.

  1. eGovFrame VSCode Initializr에서 AOP 기반 트랜잭션 설정으로 Java Config 파일 생성
  2. `@Configuration(proxyBeanMethods = false)` 적용
  3. `ApplicationRunner`로 `txAdvisor` 내부의 `advice` 인스턴스와 Spring 컨텍스트의 `txAdvice` 빈이 동일 인스턴스인지 확인

```
  수정 전 결과:
  === [Issue 2] proxyBeanMethods=false (직접 메서드 호출 버그) ===
  Spring 관리 txAdvice@1028908791
  txAdvisor 내부 advice@ 395686760
  → 동일 인스턴스: false
  → [BUG] 별개 인스턴스 생성됨 — Spring 생명주기 미적용, 트랜잭션 미적용 위험

  수정 후 결과:
  === [Issue 2] proxyBeanMethods=false ===
  Spring 관리 txAdvice@1373254373
  txAdvisor 내부 advice@ 1373254373
  → 동일 인스턴스: true 
```


## 스크린샷 (Screenshots)
**<정상적으로 코드 생성>**
<img width="1191" height="224" alt="스크린샷 2026-05-29 오후 1 01 02" src="https://github.com/user-attachments/assets/26132e3d-432a-47a1-8917-e8657fe105d7" />


## 체크리스트 (Checklist)

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [x] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [x] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [x] Extension Development Host(F5)에서 동작을 확인했습니다.
- [ ] Webview 변경이 있는 경우 `cd webview-ui && npm run test` 를 통과했습니다.
- [x] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.
- [x] 필요한 경우 관련 문서(README, CONTRIBUTING, CLAUDE.md 등)를 업데이트했습니다.

## 추가 참고 사항 (Additional Notes)

AOP 기반 트랜잭션 설정(`chkAopConfigTransaction`) 선택 시에만 해당 코드가 생성되며, XML 기반 트랜잭션 설정 및 CRUD 코드 생성 템플릿에는 영향이 없습니다.

변경된 템플릿 파일 목록:
- `templates/config/transaction/datasource-java.hbs`
- `templates/config/transaction/jpa-java.hbs` 
- `templates/config/transaction/jta-java.hbs`


