### PR TITLE
fix : TEXT, BlOB, BYTE 타입을 각 String, byte[], byte[]로 변환하는 코드 추가

### DIFF
--- a/src/shared/dataTypes.ts
+++ b/src/shared/dataTypes.ts
@@ -43,6 +43,17 @@ const predefinedDataTypes: { [key: string]: string } = {
 	// MySQL specific types
 	ENUM: "java.lang.String",
 	SET: "java.lang.String",
+	TINYTEXT: "java.lang.String",
+	LONGTEXT: "java.lang.String",
+	TINYBLOB: "byte[]",
+	MEDIUMBLOB: "byte[]",
+	LONGBLOB: "byte[]",
+	BLOB: "byte[]",
+	BINARY: "byte[]",
+	VARBINARY: "byte[]",
+
+	// PostgreSQL specific types
+	BYTEA: "byte[]",
 }
 
 /**

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -122,6 +122,63 @@ describe("ddlParser", () => {
 			javaType: "java.lang.Object",
 		})
 	})
+
+	it("should map MySQL text types to java.lang.String", () => {
+		const result = parseDDL(`
+			CREATE TABLE articles (
+				id INT PRIMARY KEY,
+				summary TINYTEXT,
+				body LONGTEXT
+			);
+		`)
+
+		expect(result.attributes[1]).toMatchObject({
+			columnName: "summary",
+			dataType: "TINYTEXT",
+			javaType: "java.lang.String",
+		})
+		expect(result.attributes[2]).toMatchObject({
+			columnName: "body",
+			dataType: "LONGTEXT",
+			javaType: "java.lang.String",
+		})
+	})
+
+	it("should map MySQL blob and binary types to byte[]", () => {
+		const result = parseDDL(`
+			CREATE TABLE blobs (
+				id INT PRIMARY KEY,
+				tiny TINYBLOB,
+				medium MEDIUMBLOB,
+				large LONGBLOB,
+				data BLOB,
+				fixed BINARY(16),
+				variable VARBINARY(255)
+			);
+		`)
+
+		expect(result.attributes[1]).toMatchObject({ columnName: "tiny", dataType: "TINYBLOB", javaType: "byte[]" })
+		expect(result.attributes[2]).toMatchObject({ columnName: "medium", dataType: "MEDIUMBLOB", javaType: "byte[]" })
+		expect(result.attributes[3]).toMatchObject({ columnName: "large", dataType: "LONGBLOB", javaType: "byte[]" })
+		expect(result.attributes[4]).toMatchObject({ columnName: "data", dataType: "BLOB", javaType: "byte[]" })
+		expect(result.attributes[5]).toMatchObject({ columnName: "fixed", dataType: "BINARY", javaType: "byte[]" })
+		expect(result.attributes[6]).toMatchObject({ columnName: "variable", dataType: "VARBINARY", javaType: "byte[]" })
+	})
+
+	it("should map PostgreSQL BYTEA type to byte[]", () => {
+		const result = parseDDL(`
+			CREATE TABLE pg_files (
+				id INT PRIMARY KEY,
+				content BYTEA
+			);
+		`)
+
+		expect(result.attributes[1]).toMatchObject({
+			columnName: "content",
+			dataType: "BYTEA",
+			javaType: "byte[]",
+		})
+	})
 })
 
 describe("validateDDL", () => {


### PR DESCRIPTION

## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일/UI 변경 (style)
- [ ] 테스트 추가/수정 (test)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->
`src/shared/dataTypes.ts`에 MySQL·PostgreSQL에서 자주 사용하는 바이너리·텍스트 타입 매핑을 추가하였습니다.
기존에 누락된 타입들이 `java.lang.Object`로 생성되는 VO를 수정하였습니다.

```typescript
// MySQL specific types 추가
TINYTEXT:   "java.lang.String",
LONGTEXT:   "java.lang.String",
TINYBLOB:   "byte[]",
MEDIUMBLOB: "byte[]",
LONGBLOB:   "byte[]",
BLOB:       "byte[]",
BINARY:     "byte[]",
VARBINARY:  "byte[]",

// PostgreSQL specific types 추가
BYTEA:      "byte[]",
```

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->
#15 


## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 프로젝트 생성 (Project Generation)
- [x] CRUD 코드 생성 (Code Generation)
- [ ] 설정 파일 생성 (Config Generation)
- [ ] Extension 코어 (`src/core`)
- [ ] Webview UI (`webview-ui`)
- [ ] 템플릿 (`templates/`)
- [ ] 문서 / 기타

## 테스트 방법 (How Has This Been Tested?)

<!-- 변경 사항을 어떻게 확인했는지 재현 가능한 절차로 작성해주세요. -->

1. 빌드 및 실행
  F5  →  "Run Extension" 선택(preLaunchTask가 자동으로 npm run compile 실행)

2. 사이드바 열기
  새 창 왼쪽 액티비티바 → eGovFrame 아이콘 클릭 → Code Generation 탭 선택

3.  DDL 입력 후 생성
```
-- MySQL BLOB 테스트
  CREATE TABLE file_store (
      id        VARCHAR(36) PRIMARY KEY,
      thumbnail BLOB,
      content   LONGBLOB,
      body      LONGTEXT
  )

```

4. 생성된 VO 확인
```
private byte[]           thumbnail;  // ✅  Object 아님
private byte[]           content;    // ✅
private java.lang.String body;       // ✅

```

## 스크린샷 (Screenshots)

<!-- UI 변경이 있다면 변경 전/후 스크린샷 또는 GIF를 첨부해주세요. -->

**변경 후:**
<img width="764" height="310" alt="image" src="https://github.com/user-attachments/assets/97618c13-a602-4a31-a5f9-a6d359f8e26c" />



## 체크리스트 (Checklist)

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [ ] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [ ] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [x] Extension Development Host(F5)에서 동작을 확인했습니다.
- [x] Webview 변경이 있는 경우 `cd webview-ui && npm run test` 를 통과했습니다.
- [x] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.
- [x] 필요한 경우 관련 문서(README, CONTRIBUTING, CLAUDE.md 등)를 업데이트했습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

**보류 항목:**

| 타입 | 보류 이유 |
|------|---------|
| `UUID → String` | `egovIdGnrService`가 UUID 형식이 아닌 값을 반환해 PostgreSQL UUID 컬럼에 INSERT 시 런타임 오류 발생 가능. ServiceImpl 템플릿 개선과 함께 별도 대응 필요 |
| `JSON → String` | 팀마다 `String`, `Map<String,Object>`, 커스텀 DTO 등 처리 방식이 달라 단일 표준으로 확정하기 어려움 |
| `JSONB → String` | `String` 매핑은 가능하나 Mapper XML에 `jdbcType="OTHER"` 없으면 INSERT/UPDATE 실패가능성. 매퍼 템플릿 수정과 함께 별도 PR에서 대응 필요 |
