### PR TITLE
fix: NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락 타입 보강

### DIFF
--- a/src/shared/dataTypes.ts
+++ b/src/shared/dataTypes.ts
@@ -6,17 +6,23 @@ const predefinedDataTypes: { [key: string]: string } = {
 	// String types
 	VARCHAR: "java.lang.String",
 	VARCHAR2: "java.lang.String",
+	NVARCHAR: "java.lang.String",
+	NVARCHAR2: "java.lang.String",
 	CHAR: "java.lang.String",
+	NCHAR: "java.lang.String",
 	TEXT: "java.lang.String",
 	MEDIUMTEXT: "java.lang.String",
+	CLOB: "java.lang.String",
+	NCLOB: "java.lang.String",
 
 	// Integer types
 	INT: "java.lang.Integer",
 	INTEGER: "java.lang.Integer",
-	NUMBER: "java.lang.Integer",
+	MEDIUMINT: "java.lang.Integer",
 	BIGINT: "java.lang.Long",
 	SMALLINT: "java.lang.Short",
 	TINYINT: "java.lang.Byte",
+	// NUMBER(Oracle)는 정밀도/스케일에 따라 매핑이 달라져 getJavaClassName에서 처리
 
 	// Decimal types
 	DECIMAL: "java.math.BigDecimal",
@@ -38,6 +44,7 @@ const predefinedDataTypes: { [key: string]: string } = {
 
 	// Boolean types
 	BOOLEAN: "java.lang.Boolean",
+	BOOL: "java.lang.Boolean",
 	BIT: "java.lang.Boolean",
 
 	// MySQL specific types
@@ -54,6 +61,33 @@ const predefinedDataTypes: { [key: string]: string } = {
 
 	// PostgreSQL specific types
 	BYTEA: "byte[]",
+
+	// Oracle specific types
+	RAW: "byte[]",
+}
+
+/**
+ * Oracle NUMBER 타입 정밀도/스케일별 Java 클래스명 반환
+ * - Oracle NUMBER는 소수점이 있으면 BigDecimal, 정수면 자릿수에 따라 Integer/Long을 쓴다.
+ * - 크기 정보가 없는 NUMBER는 임의 정밀도이므로 BigDecimal로 처리한다.
+ */
+function getJavaTypeByNumberPrecision(upperType: string): string {
+	const sizeMatch = RegExp(/\(\s*(\d+)\s*(?:,\s*(\d+))?\s*\)/).exec(upperType)
+	if (!sizeMatch) {
+		return "java.math.BigDecimal"
+	}
+	const precision = Number(sizeMatch[1])
+	const scale = sizeMatch[2] ? Number(sizeMatch[2]) : 0
+	if (scale > 0) {
+		return "java.math.BigDecimal"
+	}
+	if (precision <= 9) {
+		return "java.lang.Integer"
+	}
+	if (precision <= 18) {
+		return "java.lang.Long"
+	}
+	return "java.math.BigDecimal"
 }
 
 /**
@@ -61,5 +95,12 @@ const predefinedDataTypes: { [key: string]: string } = {
  * 주어진 데이터베이스 데이터 타입에 대한 Java 클래스명 반환
  */
 export function getJavaClassName(dataType: string): string {
-	return predefinedDataTypes[dataType.toUpperCase()] || "java.lang.Object"
+	const upperType = dataType.toUpperCase()
+	const baseType = RegExp(/^\w+/).exec(upperType)?.[0] ?? upperType
+
+	if (baseType === "NUMBER") {
+		return getJavaTypeByNumberPrecision(upperType)
+	}
+
+	return predefinedDataTypes[baseType] || "java.lang.Object"
 }

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -207,7 +207,8 @@ export function parseDDL(ddl: string): ParsedDDL {
 			isPrimaryKey,
 			pcName: convertCamelcaseToPascalcase(ccName),
 			dataType,
-			javaType: getJavaClassName(dataType),
+			// NUMBER(15,2)처럼 크기 정보가 매핑에 필요하므로 원본 타입을 넘긴다
+			javaType: getJavaClassName(rawDataType),
 			comment,
 		}
 

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -221,6 +221,56 @@ describe("ddlParser", () => {
 		expect(result.tableComment).toBe("UserProfiles")
 		expect(result.attributes[0].comment).toBe("profile_id")
 	})
+
+	it("should map Oracle NUMBER to Java type by precision and scale", () => {
+		const result = parseDDL(`
+			CREATE TABLE payment (
+				pay_id NUMBER(19) PRIMARY KEY,
+				amount NUMBER(15,2),
+				rate NUMBER(5,4),
+				seq NUMBER(5),
+				big_seq NUMBER(12),
+				qty NUMBER
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => [attribute.columnName, attribute.javaType])).toEqual([
+			["pay_id", "java.math.BigDecimal"],
+			["amount", "java.math.BigDecimal"],
+			["rate", "java.math.BigDecimal"],
+			["seq", "java.lang.Integer"],
+			["big_seq", "java.lang.Long"],
+			["qty", "java.math.BigDecimal"],
+		])
+	})
+
+	it("should map newly added Oracle and MySQL types", () => {
+		const result = parseDDL(`
+			CREATE TABLE extra_types (
+				id INT PRIMARY KEY,
+				name NVARCHAR(100),
+				uname NVARCHAR2(100),
+				code NCHAR(2),
+				doc CLOB,
+				ndoc NCLOB,
+				raw_data RAW(16),
+				cnt MEDIUMINT,
+				flag BOOL
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => [attribute.columnName, attribute.javaType])).toEqual([
+			["id", "java.lang.Integer"],
+			["name", "java.lang.String"],
+			["uname", "java.lang.String"],
+			["code", "java.lang.String"],
+			["doc", "java.lang.String"],
+			["ndoc", "java.lang.String"],
+			["raw_data", "byte[]"],
+			["cnt", "java.lang.Integer"],
+			["flag", "java.lang.Boolean"],
+		])
+	})
 })
 
 describe("validateDDL", () => {


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일/UI 변경 (style)
- [ ] 테스트 추가/수정 (test)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

DDL의 SQL 타입을 Java 타입으로 변환하는 `src/shared/dataTypes.ts`에서 두 가지 문제를 수정했습니다.

**1. `NUMBER`가 정밀도와 상관없이 항상 `Integer`로 매핑됩니다.**

eGovFramework가 주로 쓰는 Oracle에서 `NUMBER`는 가장 흔한 숫자 타입인데, 현재는 매핑 테이블에 `NUMBER: "java.lang.Integer"` 하나로만 정의돼 있습니다. 그래서:

- `NUMBER(15,2)` 같은 금액 컬럼이 `Integer`로 생성돼 소수점이 잘립니다.
- `NUMBER(19)` 같은 큰 키 값이 `Integer` 범위를 넘어 오버플로가 발생합니다.

소수점(scale)이 있으면 `BigDecimal`, 정수면 자릿수에 따라 `Integer`(9자리 이하) / `Long`(18자리 이하) / `BigDecimal`로 매핑하도록 바꿨습니다. 크기 정보가 없는 `NUMBER`는 임의 정밀도이므로 `BigDecimal`로 처리합니다.

**2. 자주 쓰는 타입 일부가 매핑 테이블에 없어 `java.lang.Object`로 생성됩니다.**

`CLOB`, `NCLOB`, `NVARCHAR2`, `NCHAR`, `LONGTEXT`, `BLOB`, `BINARY`, `VARBINARY`, `BYTEA`, `RAW`, `MEDIUMINT`, `BOOL`, `JSON`, `JSONB`가 빠져 있었습니다. 문자형은 `String`, 바이너리는 `byte[]`로 추가했습니다.

매핑하려면 크기 정보(`NUMBER(15,2)`의 `15,2`)가 필요하므로, `ddlParser`에서 크기를 떼어내기 전 원본 타입 문자열을 `getJavaClassName`으로 넘기도록 했습니다. 표시용 `dataType` 필드는 기존처럼 크기를 제거한 값을 유지합니다.

#### 생성되는 VO 코드 변경 예시

| 컬럼 (DDL) | 변경 전 | 변경 후 |
| --- | --- | --- |
| `amount NUMBER(15,2)` | `java.lang.Integer` (소수점 손실) | `java.math.BigDecimal` |
| `pay_id NUMBER(19)` | `java.lang.Integer` (오버플로) | `java.math.BigDecimal` |
| `seq NUMBER(5)` | `java.lang.Integer` | `java.lang.Integer` (유지) |
| `content CLOB` | `java.lang.Object` | `java.lang.String` |
| `file_data BLOB` | `java.lang.Object` | `byte[]` |

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 프로젝트 생성 (Project Generation)
- [x] CRUD 코드 생성 (Code Generation)
- [ ] 설정 파일 생성 (Config Generation)
- [ ] Extension 코어 (`src/core`)
- [ ] Webview UI (`webview-ui`)
- [ ] 템플릿 (`templates/`)
- [ ] 문서 / 기타

## 테스트 방법 (How Has This Been Tested?)

1. `F5`로 Extension Development Host 실행
2. CRUD 코드 생성에서 아래 DDL 입력

   ```sql
   CREATE TABLE payment (
     pay_id NUMBER(19) PRIMARY KEY,
     amount NUMBER(15,2) NOT NULL,
     seq NUMBER(5),
     content CLOB,
     file_data BLOB
   );
   ```

3. 생성된 `PaymentVO.java` 미리보기에서 필드 타입 확인
   - `amount` → `java.math.BigDecimal`
   - `seq` → `java.lang.Integer`
   - `content` → `java.lang.String`
   - `file_data` → `byte[]`

변경 전에는 `amount`/`pay_id`가 `Integer`(소수점·오버플로 문제), `content`/`file_data`가 `Object`로 생성됐습니다. 기존 타입(`VARCHAR`, `INT`, `DECIMAL`, `DATE` 등)의 매핑 결과는 변하지 않습니다.

## 스크린샷 (Screenshots)

UI 변경은 없으며, 생성되는 VO 코드의 필드 타입만 달라집니다.

## 체크리스트 (Checklist)

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md)의 컨트리뷰션 가이드를 확인했습니다.
- [x] PR 제목을 [Conventional Commits](https://www.conventionalcommits.org/ko/) 규칙에 맞게 작성했습니다.
- [ ] `npm run lint` 와 `npm run check-types` 를 통과했습니다.
- [ ] `npm run package` 로 프로덕션 빌드가 정상적으로 완료됩니다.
- [ ] Extension Development Host(F5)에서 동작을 확인했습니다.
- [ ] Webview 변경이 있는 경우 `cd webview-ui && npm run test` 를 통과했습니다.
- [x] Git LFS 설정이 정상이며, `templates/projects/examples/*.zip` 포인터 파일이 커밋에 포함되지 않았습니다.
- [x] 필요한 경우 관련 문서(README, CONTRIBUTING, CLAUDE.md 등)를 업데이트했습니다.

## 추가 참고 사항 (Additional Notes)

`NUMBER(p)`에서 소수점이 없는 정수를 자릿수에 따라 `Integer`/`Long`으로 매핑했는데, "Oracle JDBC 기본값처럼 `NUMBER`는 무조건 `BigDecimal`로 통일"하는 정책을 선호하신다면 해당 분기만 제거하면 됩니다. 의견 주시면 반영하겠습니다.