### PR TITLE
[보안] handlebars 4.7.8 → 4.7.9 (CVE-2026-33937 외 취약점 8종)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"extract-zip": "2.0.1",
 				"fs-extra": "11.2.0",
-				"handlebars": "4.7.8"
+				"handlebars": "4.7.9"
 			},
 			"devDependencies": {
 				"@types/fs-extra": "11.0.4",
@@ -4039,9 +4039,9 @@
 			"license": "MIT"
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,6 @@
 	"dependencies": {
 		"extract-zip": "2.0.1",
 		"fs-extra": "11.2.0",
-		"handlebars": "4.7.8"
+		"handlebars": "4.7.9"
 	}
 }


### PR DESCRIPTION
## 개요

handlebars 4.7.8에 JS Injection·Prototype Pollution 등 다수 취약점이 보고되어 4.7.9에서 패치되었습니다. 4.7.9는 OSV.dev 기준 알려진 취약점이 없는 4.7.x 최신 버전입니다.

## 해소되는 취약점 (handlebars 4.7.8 영향, 모두 4.7.9에서 해소)

- CVE-2026-33937 (GHSA-2w6w-674q-4c4q): AST Type Confusion 통한 JavaScript Injection
- CVE-2026-33916 (GHSA-2qvq-rjwj-gvw9): Partial Template Injection 통한 Prototype Pollution → XSS
- CVE-2026-33938 (GHSA-3mfm-83xf-c92r): @partial-block 변조 AST Type Confusion
- CVE-2026-33940 (GHSA-xhpv-hc6g-r9c6): dynamic 객체 전달 시 AST Type Confusion
- CVE-2026-33941 (GHSA-xjpj-3mr7-gcpf): CLI Precompiler 통한 JavaScript Injection
- CVE-2026-33939 (GHSA-9cx6-37pm-9jff): Decorator 구문 DoS
- GHSA-442j-39wm-28r2: container.lookup Property Access 검증 우회
- GHSA-7rx3-28cr-v5wh: `__lookupSetter__` 미차단 Prototype Method 접근

## 변경 사항

- `package.json`: handlebars `4.7.8` → `4.7.9`
- `package-lock.json`: `npm install`로 갱신

## 검증

- `npm install` 정상 완료
- patch 범프로 breaking change 없음