### PR TITLE
[보안] webview-ui vite 6.3.4 → 6.4.3 (dev server 취약점 7종)

### DIFF
--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -46,7 +46,7 @@
 				"tailwindcss": "4.1.5",
 				"typescript": "5.7.3",
 				"typescript-eslint": "8.25.0",
-				"vite": "6.4.2",
+				"vite": "6.4.3",
 				"vitest": "3.0.9"
 			},
 			"optionalDependencies": {
@@ -9088,9 +9088,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -46,7 +46,7 @@
 				"tailwindcss": "4.1.5",
 				"typescript": "5.7.3",
 				"typescript-eslint": "8.25.0",
-				"vite": "6.3.4",
+				"vite": "6.4.2",
 				"vitest": "3.0.9"
 			},
 			"optionalDependencies": {
@@ -9088,9 +9088,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.3.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-			"integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -53,7 +53,7 @@
 		"tailwindcss": "4.1.5",
 		"typescript": "5.7.3",
 		"typescript-eslint": "8.25.0",
-		"vite": "6.3.4",
+		"vite": "6.4.2",
 		"vitest": "3.0.9"
 	},
 	"optionalDependencies": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -53,7 +53,7 @@
 		"tailwindcss": "4.1.5",
 		"typescript": "5.7.3",
 		"typescript-eslint": "8.25.0",
-		"vite": "6.4.2",
+		"vite": "6.4.3",
 		"vitest": "3.0.9"
 	},
 	"optionalDependencies": {


### PR DESCRIPTION
## 개요

webview-ui가 사용하는 vite 6.3.4에 dev server 관련 취약점이 다수 보고되어, 6.x 라인 최신 패치인 6.4.3으로 올립니다. 6.4.3은 OSV.dev 기준 알려진 취약점이 없습니다.

## 해소되는 취약점 (vite 6.3.4 영향, 모두 6.4.3에서 해소)

- CVE-2026-39365 (GHSA-4w7w-66w2-5vf9): Optimized Deps `.map` 처리 Path Traversal
- CVE-2026-39363 (GHSA-p9ff-h696-f583): Dev Server WebSocket 통한 임의 파일 읽기
- CVE-2025-62522 (GHSA-93m4-6634-74q7): Windows 백슬래시로 `server.fs.deny` 우회
- CVE-2025-58751 (GHSA-g4jq-h2w9-997c): public 디렉토리 동일 접두 파일 노출
- CVE-2025-58752 (GHSA-jqfw-vq24-v9c3): HTML 파일에 `server.fs` 설정 미적용
- CVE-2026-53571 (GHSA-fx2h-pf6j-xcff): Windows alternate path로 `server.fs.deny` 우회
- CVE-2026-53632 (GHSA-v6wh-96g9-6wx3): launch-editor NTLMv2 해시 노출(UNC 경로)

> 6.4.2까지로는 마지막 두 건(CVE-2026-53571, CVE-2026-53632)이 잔존하여 6.4.3으로 올립니다.

## 변경 사항

- `webview-ui/package.json`: vite `6.3.4` → `6.4.3`
- `webview-ui/package-lock.json`: `npm install`로 갱신

## 검증

- `npm install` 정상 완료, 설치 버전 6.4.3 확인
- `npm run build` (vite v6.4.3) 정상 빌드 (1099 modules transformed)
- 6.x 라인 내 패치 범프로 빌드 호환성 영향 없음