### PR TITLE
[test] webview-ui 유틸 함수 단위 테스트 추가

### DIFF
--- a/webview-ui/src/utils/__tests__/dataTypes.spec.ts
+++ b/webview-ui/src/utils/__tests__/dataTypes.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest"
+import { getJavaClassName } from "@shared/dataTypes"
+
+describe("getJavaClassName", () => {
+	it("문자열 타입을 java.lang.String으로 변환한다", () => {
+		expect(getJavaClassName("VARCHAR")).toBe("java.lang.String")
+		expect(getJavaClassName("VARCHAR2")).toBe("java.lang.String")
+		expect(getJavaClassName("CHAR")).toBe("java.lang.String")
+		expect(getJavaClassName("TEXT")).toBe("java.lang.String")
+		expect(getJavaClassName("MEDIUMTEXT")).toBe("java.lang.String")
+	})
+
+	it("정수 타입을 적절한 Java 타입으로 변환한다", () => {
+		expect(getJavaClassName("INT")).toBe("java.lang.Integer")
+		expect(getJavaClassName("INTEGER")).toBe("java.lang.Integer")
+		expect(getJavaClassName("NUMBER")).toBe("java.lang.Integer")
+		expect(getJavaClassName("BIGINT")).toBe("java.lang.Long")
+		expect(getJavaClassName("SMALLINT")).toBe("java.lang.Short")
+		expect(getJavaClassName("TINYINT")).toBe("java.lang.Byte")
+	})
+
+	it("소수 타입을 적절한 Java 타입으로 변환한다", () => {
+		expect(getJavaClassName("DECIMAL")).toBe("java.math.BigDecimal")
+		expect(getJavaClassName("NUMERIC")).toBe("java.math.BigDecimal")
+		expect(getJavaClassName("FLOAT")).toBe("java.lang.Float")
+		expect(getJavaClassName("REAL")).toBe("java.lang.Double")
+		expect(getJavaClassName("DOUBLE")).toBe("java.lang.Double")
+	})
+
+	it("PostgreSQL 시퀀스 타입을 적절한 Java 타입으로 변환한다", () => {
+		expect(getJavaClassName("SMALLSERIAL")).toBe("java.lang.Short")
+		expect(getJavaClassName("SERIAL")).toBe("java.lang.Integer")
+		expect(getJavaClassName("BIGSERIAL")).toBe("java.lang.Long")
+	})
+
+	it("날짜/시간 타입을 적절한 Java 타입으로 변환한다", () => {
+		expect(getJavaClassName("DATE")).toBe("java.sql.Date")
+		expect(getJavaClassName("TIME")).toBe("java.sql.Time")
+		expect(getJavaClassName("DATETIME")).toBe("java.util.Date")
+		expect(getJavaClassName("TIMESTAMP")).toBe("java.sql.Timestamp")
+	})
+
+	it("불리언 타입을 java.lang.Boolean으로 변환한다", () => {
+		expect(getJavaClassName("BOOLEAN")).toBe("java.lang.Boolean")
+		expect(getJavaClassName("BIT")).toBe("java.lang.Boolean")
+	})
+
+	it("MySQL 열거형 타입을 java.lang.String으로 변환한다", () => {
+		expect(getJavaClassName("ENUM")).toBe("java.lang.String")
+		expect(getJavaClassName("SET")).toBe("java.lang.String")
+	})
+
+	it("소문자 타입명을 대소문자 무관하게 처리한다", () => {
+		expect(getJavaClassName("varchar")).toBe("java.lang.String")
+		expect(getJavaClassName("int")).toBe("java.lang.Integer")
+		expect(getJavaClassName("timestamp")).toBe("java.sql.Timestamp")
+	})
+
+	it("알 수 없는 타입은 java.lang.Object를 반환한다", () => {
+		expect(getJavaClassName("JSONB")).toBe("java.lang.Object")
+		expect(getJavaClassName("UNKNOWN_TYPE")).toBe("java.lang.Object")
+		expect(getJavaClassName("XML")).toBe("java.lang.Object")
+	})
+})

--- a/webview-ui/src/utils/__tests__/projectUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/projectUtils.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest"
+import { validateProjectConfig, categoriesFromProjectTemplates, getTemplatesByCategory } from "../projectUtils"
+import type { ProjectTemplate } from "../projectUtils"
+
+const makeTemplate = (overrides: Partial<ProjectTemplate> = {}): ProjectTemplate => ({
+	displayName: "Sample Template",
+	fileName: "sample.zip",
+	pomFile: "pom.xml",
+	...overrides,
+})
+
+describe("validateProjectConfig", () => {
+	it("projectName이 없으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "",
+			template: makeTemplate(),
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain("Project name is required")
+	})
+
+	it("projectName이 공백만이면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "   ",
+			template: makeTemplate(),
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain("Project name is required")
+	})
+
+	it("outputPath가 없으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate(),
+			outputPath: "",
+			groupId: "egovframework.com",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain("Output path is required")
+	})
+
+	it("template이 없으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain("Template selection is required")
+	})
+
+	it("pomFile이 있는 템플릿에서 groupId가 없으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain("Group ID is required for this template")
+	})
+
+	it("groupId가 유효하지 않은 형식이면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "Invalid.Group",
+			artifactId: "my-project",
+		})
+		expect(errors.some((e) => e.includes("Group ID must start"))).toBe(true)
+	})
+
+	it("groupId가 점으로 끝나면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "egovframework.",
+			artifactId: "my-project",
+		})
+		expect(errors.some((e) => e.includes("Group ID must start"))).toBe(true)
+	})
+
+	it("pomFile이 있는 템플릿에서 artifactId가 없으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "",
+		})
+		expect(errors).toContain("Artifact ID is required for this template")
+	})
+
+	it("artifactId가 유효하지 않은 형식이면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "My_Project",
+		})
+		expect(errors.some((e) => e.includes("Artifact ID must start"))).toBe(true)
+	})
+
+	it("pomFile이 없는 템플릿에서는 groupId/artifactId를 검증하지 않는다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "" }),
+			outputPath: "/tmp",
+		})
+		expect(errors).not.toContain("Group ID is required for this template")
+		expect(errors).not.toContain("Artifact ID is required for this template")
+	})
+
+	it("모든 필드가 유효하면 빈 배열을 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "egovframework.com",
+			artifactId: "my-project",
+		})
+		expect(errors).toHaveLength(0)
+	})
+})
+
+describe("categoriesFromProjectTemplates", () => {
+	it("빈 배열이면 'All'만 반환한다", () => {
+		expect(categoriesFromProjectTemplates([])).toEqual(["All"])
+	})
+
+	it("카테고리가 없는 템플릿만 있으면 'All'만 반환한다", () => {
+		const templates = [makeTemplate({ category: undefined }), makeTemplate({ category: undefined })]
+		expect(categoriesFromProjectTemplates(templates)).toEqual(["All"])
+	})
+
+	it("카테고리를 중복 없이 반환한다", () => {
+		const templates = [
+			makeTemplate({ category: "Template" }),
+			makeTemplate({ category: "Template" }),
+			makeTemplate({ category: "Sample" }),
+		]
+		const categories = categoriesFromProjectTemplates(templates)
+		expect(categories).toEqual(["All", "Template", "Sample"])
+	})
+
+	it("'All'은 항상 첫 번째로 반환된다", () => {
+		const templates = [makeTemplate({ category: "Sample" })]
+		const categories = categoriesFromProjectTemplates(templates)
+		expect(categories[0]).toBe("All")
+	})
+
+	it("카테고리 등장 순서를 유지한다", () => {
+		const templates = [makeTemplate({ category: "C" }), makeTemplate({ category: "A" }), makeTemplate({ category: "B" })]
+		const categories = categoriesFromProjectTemplates(templates)
+		expect(categories).toEqual(["All", "C", "A", "B"])
+	})
+})
+
+describe("getTemplatesByCategory", () => {
+	const templates: ProjectTemplate[] = [
+		makeTemplate({ displayName: "T1", category: "Template" }),
+		makeTemplate({ displayName: "T2", category: "Sample" }),
+		makeTemplate({ displayName: "T3", category: "Template" }),
+		makeTemplate({ displayName: "T4" }),
+	]
+
+	it("'All' 카테고리이면 전체 템플릿을 반환한다", () => {
+		expect(getTemplatesByCategory(templates, "All")).toEqual(templates)
+	})
+
+	it("특정 카테고리에 해당하는 템플릿만 반환한다", () => {
+		const result = getTemplatesByCategory(templates, "Template")
+		expect(result).toHaveLength(2)
+		expect(result.every((t) => t.category === "Template")).toBe(true)
+	})
+
+	it("해당하는 카테고리가 없으면 빈 배열을 반환한다", () => {
+		expect(getTemplatesByCategory(templates, "NonExistent")).toHaveLength(0)
+	})
+})

--- a/webview-ui/src/utils/__tests__/settingsUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/settingsUtils.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest"
+import { validateEgovSettings } from "../settingsUtils"
+
+describe("validateEgovSettings", () => {
+	it("모든 필드가 유효하면 빈 배열을 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example.sample",
+		})
+		expect(errors).toHaveLength(0)
+	})
+
+	it("defaultGroupId가 없으면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors).toContain("Default Group ID is required")
+	})
+
+	it("defaultGroupId가 공백만이면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "   ",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors).toContain("Default Group ID is required")
+	})
+
+	it("defaultGroupId가 대문자를 포함하면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "EgovFramework.com",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors.some((e) => e.includes("Default Group ID must start"))).toBe(true)
+	})
+
+	it("defaultGroupId가 점으로 끝나면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors.some((e) => e.includes("Default Group ID must start"))).toBe(true)
+	})
+
+	it("defaultGroupId가 숫자로 시작하면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "1egovframework",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors.some((e) => e.includes("Default Group ID must start"))).toBe(true)
+	})
+
+	it("defaultArtifactId가 없으면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors).toContain("Default Artifact ID is required")
+	})
+
+	it("defaultArtifactId에 언더스코어가 포함되면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "my_project",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors.some((e) => e.includes("Default Artifact ID must start"))).toBe(true)
+	})
+
+	it("defaultArtifactId가 대문자를 포함하면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "MyProject",
+			defaultPackageName: "egovframework.example",
+		})
+		expect(errors.some((e) => e.includes("Default Artifact ID must start"))).toBe(true)
+	})
+
+	it("defaultPackageName이 없으면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "",
+		})
+		expect(errors).toContain("Default Package Name is required")
+	})
+
+	it("defaultPackageName이 점으로 끝나면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "egovframework.com",
+			defaultArtifactId: "my-project",
+			defaultPackageName: "egovframework.example.",
+		})
+		expect(errors.some((e) => e.includes("Default Package Name must start"))).toBe(true)
+	})
+
+	it("여러 필드가 동시에 잘못되면 모든 오류를 반환한다", () => {
+		const errors = validateEgovSettings({
+			defaultGroupId: "",
+			defaultArtifactId: "",
+			defaultPackageName: "",
+		})
+		expect(errors).toContain("Default Group ID is required")
+		expect(errors).toContain("Default Artifact ID is required")
+		expect(errors).toContain("Default Package Name is required")
+		expect(errors).toHaveLength(3)
+	})
+
+	it("필드가 undefined이면 오류를 반환한다", () => {
+		const errors = validateEgovSettings({})
+		expect(errors).toContain("Default Group ID is required")
+		expect(errors).toContain("Default Artifact ID is required")
+		expect(errors).toContain("Default Package Name is required")
+	})
+})

--- a/webview-ui/src/utils/__tests__/templateUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/templateUtils.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest"
+import { groupTemplates } from "../templateUtils"
+import type { TemplateConfig } from "@components/egov/types/templates"
+
+const makeTemplateConfig = (displayName: string, overrides: Partial<TemplateConfig> = {}): TemplateConfig => ({
+	displayName,
+	templateFolder: "folder",
+	templateFile: "template.xml",
+	webView: "view",
+	fileNameProperty: "fileName",
+	javaConfigTemplate: "javaConfig.java",
+	yamlTemplate: "template.yaml",
+	propertiesTemplate: "template.properties",
+	description: "설명",
+	...overrides,
+})
+
+describe("groupTemplates", () => {
+	it("빈 배열이면 빈 객체를 반환한다", () => {
+		expect(groupTemplates([])).toEqual({})
+	})
+
+	it("'카테고리 > 서브카테고리' 형식으로 그룹화한다", () => {
+		const templates = [
+			makeTemplateConfig("Datasource > MySQL"),
+			makeTemplateConfig("Datasource > PostgreSQL"),
+			makeTemplateConfig("Logging > Log4j"),
+		]
+		const grouped = groupTemplates(templates)
+
+		expect(Object.keys(grouped)).toEqual(["Datasource", "Logging"])
+		expect(Object.keys(grouped["Datasource"])).toEqual(["MySQL", "PostgreSQL"])
+		expect(Object.keys(grouped["Logging"])).toEqual(["Log4j"])
+	})
+
+	it("그룹화된 값은 원본 TemplateConfig 객체다", () => {
+		const template = makeTemplateConfig("Datasource > MySQL")
+		const grouped = groupTemplates([template])
+
+		expect(grouped["Datasource"]["MySQL"]).toBe(template)
+	})
+
+	it("구분자('>')가 없는 displayName은 무시한다", () => {
+		const templates = [makeTemplateConfig("InvalidDisplayName"), makeTemplateConfig("Datasource > MySQL")]
+		const grouped = groupTemplates(templates)
+
+		expect(Object.keys(grouped)).not.toContain("InvalidDisplayName")
+		expect(grouped["Datasource"]["MySQL"]).toBeDefined()
+	})
+
+	it("같은 서브카테고리가 여러 번 등장하면 마지막 값으로 덮어쓴다", () => {
+		const first = makeTemplateConfig("Datasource > MySQL", { description: "첫 번째" })
+		const second = makeTemplateConfig("Datasource > MySQL", { description: "두 번째" })
+		const grouped = groupTemplates([first, second])
+
+		expect(grouped["Datasource"]["MySQL"].description).toBe("두 번째")
+	})
+
+	it("displayName에 구분자가 2개 이상이면 첫 두 부분으로만 그룹화한다", () => {
+		const template = makeTemplateConfig("Category > Subcategory > Detail")
+		const grouped = groupTemplates([template])
+
+		expect(grouped["Category"]["Subcategory"]).toBe(template)
+	})
+
+	it("여러 카테고리와 서브카테고리를 올바르게 처리한다", () => {
+		const templates = [
+			makeTemplateConfig("Cache > EhCache"),
+			makeTemplateConfig("Cache > Hazelcast"),
+			makeTemplateConfig("Transaction > JPA"),
+			makeTemplateConfig("Transaction > JDBC"),
+			makeTemplateConfig("Scheduling > Quartz"),
+		]
+		const grouped = groupTemplates(templates)
+
+		expect(Object.keys(grouped)).toHaveLength(3)
+		expect(Object.keys(grouped["Cache"])).toHaveLength(2)
+		expect(Object.keys(grouped["Transaction"])).toHaveLength(2)
+		expect(Object.keys(grouped["Scheduling"])).toHaveLength(1)
+	})
+})


### PR DESCRIPTION
## 변경 내용

webview-ui의 순수 유틸 함수 4종에 대한 단위 테스트를 추가합니다.

### 대상 함수

- `src/shared/dataTypes.ts` — `getJavaClassName`
- `webview-ui/src/utils/projectUtils.ts` — `validateProjectConfig`, `categoriesFromProjectTemplates`, `getTemplatesByCategory`
- `webview-ui/src/utils/settingsUtils.ts` — `validateEgovSettings`
- `webview-ui/src/utils/templateUtils.ts` — `groupTemplates`

### 추가된 테스트 파일

- `webview-ui/src/utils/__tests__/dataTypes.spec.ts` — 9개 케이스
- `webview-ui/src/utils/__tests__/projectUtils.spec.ts` — 19개 케이스
- `webview-ui/src/utils/__tests__/settingsUtils.spec.ts` — 13개 케이스
- `webview-ui/src/utils/__tests__/templateUtils.spec.ts` — 7개 케이스

총 48개 케이스. 정상 입력, 경계값, 오류 시나리오를 포함합니다.

### 테스트 실행 결과

```
Test Files  8 passed (8)
     Tests  67 passed (67)
  Duration  1.18s
```

기존 테스트 포함 전체 67개 모두 통과하였습니다.

### 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
