### PR TITLE
refactor: 불필요한 try/catch 제거 (no-useless-catch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Code Generation
   - DDL 입력 내용을 기반으로 테이블, 컬럼, PK/FK, 1:N 관계를 표시하는 ERD Preview 추가
+- Refactoring
+  - 불필요한 try/catch(no-useless-catch) 제거 (codeGenerator.ts)
 
 ## v5.0.0 Beta (2025-12-04)
 

--- a/src/utils/codeGenerator.ts
+++ b/src/utils/codeGenerator.ts
@@ -343,25 +343,21 @@ export async function uploadTemplates(ddl: string, packageName: string): Promise
 		const templatePath = file.fsPath
 		const outputPath = path.join(selectedFolderPath, path.basename(file.fsPath, ".hbs") + ".generated")
 
-		try {
-			const currentParsedDDL = parseDDL(ddl)
-			const context = getTemplateContext(
-				currentParsedDDL.tableName,
-				currentParsedDDL.attributes,
-				currentParsedDDL.pkAttributes,
-				packageName,
-				currentParsedDDL.dbTableName,
-			)
-			const renderedContent = await renderTemplate(templatePath, context)
-			await fs.writeFile(outputPath, renderedContent)
-			vscode.window.showInformationMessage(`Custom template saved successfully to ${outputPath}`)
+		const currentParsedDDL = parseDDL(ddl)
+		const context = getTemplateContext(
+			currentParsedDDL.tableName,
+			currentParsedDDL.attributes,
+			currentParsedDDL.pkAttributes,
+			packageName,
+			currentParsedDDL.dbTableName,
+		)
+		const renderedContent = await renderTemplate(templatePath, context)
+		await fs.writeFile(outputPath, renderedContent)
+		vscode.window.showInformationMessage(`Custom template saved successfully to ${outputPath}`)
 
-			// Open the newly created file in the editor
-			const document = await vscode.workspace.openTextDocument(outputPath)
-			await vscode.window.showTextDocument(document)
-		} catch (error) {
-			throw error
-		}
+		// Open the newly created file in the editor
+		const document = await vscode.workspace.openTextDocument(outputPath)
+		await vscode.window.showTextDocument(document)
 	}
 }
 
@@ -384,17 +380,13 @@ export async function downloadTemplateContext(ddl: string, context: any): Promis
 
 	const folderPath = selectedFolder[0].fsPath
 
-	try {
-		const { tableName } = parseDDL(ddl)
-		const jsonContent = JSON.stringify(context, null, 2)
-		const outputPath = path.join(folderPath, `${tableName}_TemplateContext.json`)
-		await fs.writeFile(outputPath, jsonContent)
-		vscode.window.showInformationMessage(`TemplateContext JSON saved successfully to ${outputPath}`)
+	const { tableName } = parseDDL(ddl)
+	const jsonContent = JSON.stringify(context, null, 2)
+	const outputPath = path.join(folderPath, `${tableName}_TemplateContext.json`)
+	await fs.writeFile(outputPath, jsonContent)
+	vscode.window.showInformationMessage(`TemplateContext JSON saved successfully to ${outputPath}`)
 
-		// Open the newly created file in the editor
-		const document = await vscode.workspace.openTextDocument(outputPath)
-		await vscode.window.showTextDocument(document)
-	} catch (error) {
-		throw error
-	}
+	// Open the newly created file in the editor
+	const document = await vscode.workspace.openTextDocument(outputPath)
+	await vscode.window.showTextDocument(document)
 }


### PR DESCRIPTION
## 변경 이유

`src/utils/codeGenerator.ts` 의 `uploadTemplates`, `downloadTemplateContext` 함수에 있는 `try/catch` 블록은 예외를 잡아 곧바로 다시 `throw` 하기만 합니다.

```ts
try {
    // ...작업...
} catch (error) {
    throw error
}
```

이 패턴은 아무 동작도 추가하지 않는 불필요한 코드로, ESLint 의 `no-useless-catch` 규칙에 해당합니다.

## 변경 내용

두 함수의 무의미한 `try/catch` 래퍼를 제거했습니다. 래퍼를 제거해도 예외는 호출자에게 **동일하게 전파**되므로 동작 변화는 없으며, 들여쓰기 단계가 줄어 가독성이 개선됩니다.

`CHANGELOG.md` 의 Unreleased 항목도 함께 추가했습니다.

## 테스트 방법

```
npm run check-types   # tsc --noEmit
npx eslint src/utils/codeGenerator.ts
npx prettier --check src/utils/codeGenerator.ts
```

- 타입 체크 통과
- ESLint 통과(no-useless-catch 해소)
- Prettier 포맷 일치

## 영향 범위

`codeGenerator.ts` 의 예외 처리 흐름 변화 없음(예외는 그대로 호출자로 전파). 동작 변경 없는 코드 정리입니다.