### PR TITLE
fix: POM 생성 시 입력값의 '$'로 인한 pom.xml 손상 방지

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Code Generation
   - DDL 입력 내용을 기반으로 테이블, 컬럼, PK/FK, 1:N 관계를 표시하는 ERD Preview 추가
+- Project Generation
+  - POM 생성 시 입력값(프로젝트명·groupId 등)에 `$`가 포함되면 `String.replace`의 치환 특수 시퀀스로 해석되어 pom.xml이 손상되던 문제 수정
 - Refactoring
   - 불필요한 try/catch(no-useless-catch) 제거 (codeGenerator.ts)
 

--- a/src/shared/placeholderUtil.ts
+++ b/src/shared/placeholderUtil.ts
@@ -1,0 +1,19 @@
+/**
+ * 템플릿 문자열의 플레이스홀더를 치환하는 유틸리티.
+ *
+ * `String.prototype.replace`에 문자열 replacement를 넘기면 `$&`, `$1`, `$$`,
+ * `` $` `` 등이 특수 시퀀스로 해석된다. 치환값(사용자 입력 등)에 `$`가
+ * 포함되면 의도치 않게 매치 문자열이 다시 삽입되어 결과가 손상된다.
+ * 함수형 replacement를 사용하면 치환값이 항상 문자 그대로 삽입된다.
+ *
+ * @param content 원본 문자열
+ * @param replacements 플레이스홀더 → 치환값 매핑
+ * @returns 모든 플레이스홀더가 치환된 문자열
+ */
+export function replacePlaceholders(content: string, replacements: Record<string, string>): string {
+	let result = content
+	for (const [placeholder, value] of Object.entries(replacements)) {
+		result = result.replace(new RegExp(placeholder, "g"), () => value ?? "")
+	}
+	return result
+}

--- a/src/utils/projectGenerator.ts
+++ b/src/utils/projectGenerator.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import * as fs from "fs-extra"
 import * as path from "path"
 import extractZip from "extract-zip"
+import { replacePlaceholders } from "../shared/placeholderUtil"
 
 export interface EgovProjectTemplate {
 	id: string
@@ -250,9 +251,7 @@ async function generatePomFile(
 			//"{{DESCRIPTION}}": config.description || `eGovFrame project: ${config.projectName}`,
 			//"{{FRAMEWORK_VERSION}}": config.template.frameworkVersion || "4.3.0",
 		}
-		for (const [placeholder, value] of Object.entries(placeholders)) {
-			content = content.replace(new RegExp(placeholder, "g"), value)
-		}
+		content = replacePlaceholders(content, placeholders)
 
 		// Write POM file
 		await fs.writeFile(outputPath, content, "utf8")

--- a/webview-ui/src/utils/__tests__/placeholderUtil.spec.ts
+++ b/webview-ui/src/utils/__tests__/placeholderUtil.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest"
+import { replacePlaceholders } from "@shared/placeholderUtil"
+
+describe("replacePlaceholders", () => {
+	it("should replace placeholders with values", () => {
+		const result = replacePlaceholders("<name>###NAME###</name>", { "###NAME###": "MyApp" })
+		expect(result).toBe("<name>MyApp</name>")
+	})
+
+	it("should replace all occurrences of a placeholder", () => {
+		const result = replacePlaceholders("###X######X###", { "###X###": "a" })
+		expect(result).toBe("aa")
+	})
+
+	it("should handle multiple placeholders", () => {
+		const result = replacePlaceholders("###A###-###B###", { "###A###": "1", "###B###": "2" })
+		expect(result).toBe("1-2")
+	})
+
+	it("should insert values containing '$' literally", () => {
+		// String.replace의 문자열 replacement는 $&, $1, $$를 특수 처리한다.
+		// 함수형 replacement로 값을 문자 그대로 삽입해야 한다.
+		expect(replacePlaceholders("<n>###NAME###</n>", { "###NAME###": "My$&App" })).toBe("<n>My$&App</n>")
+		expect(replacePlaceholders("<n>###NAME###</n>", { "###NAME###": "a$$b" })).toBe("<n>a$$b</n>")
+		expect(replacePlaceholders("<n>###NAME###</n>", { "###NAME###": "$1$2" })).toBe("<n>$1$2</n>")
+	})
+
+	it("should treat undefined values as empty string", () => {
+		const result = replacePlaceholders("###A###", { "###A###": undefined as unknown as string })
+		expect(result).toBe("")
+	})
+})


### PR DESCRIPTION
## 문제

`generateEgovProject`로 프로젝트를 생성할 때 `generatePomFile`은 사용자 입력(프로젝트명, artifactId, groupId, version, url)을 POM 템플릿의 플레이스홀더에 치환합니다.

```ts
for (const [placeholder, value] of Object.entries(placeholders)) {
    content = content.replace(new RegExp(placeholder, "g"), value)
}
```

`String.prototype.replace`에 문자열 replacement를 넘기면 `$&`, `$1`, `$$`, `` $` `` 등이 특수 시퀀스로 해석됩니다. 따라서 치환값에 `$`가 포함되면 의도치 않게 매치된 플레이스홀더가 다시 삽입되어 pom.xml이 손상됩니다.

예) 프로젝트명이 `My$&App`이면 `###NAME###`이 `My###NAME###App`으로 치환됩니다.

```
$ node -e 'console.log("<n>###NAME###</n>".replace(/###NAME###/g, "My$&App"))'
<n>My###NAME###App</n>
```

## 수정

치환 로직을 `src/shared/placeholderUtil.ts`의 `replacePlaceholders`로 추출하고, 함수형 replacement(`() => value`)를 사용했습니다. 함수형 replacement는 반환 문자열을 그대로 삽입하므로 `$` 특수 시퀀스가 해석되지 않습니다.

```ts
result = result.replace(new RegExp(placeholder, "g"), () => value ?? "")
```

`projectGenerator`는 이 유틸을 사용하도록 변경했습니다.

## 검증

webview-ui vitest에 단위 테스트 5건을 추가했습니다.

- 기본 치환, 다중 플레이스홀더, 전역 치환
- `$&`·`$$`·`$1`이 포함된 값이 문자 그대로 삽입되는지
- undefined 값이 빈 문자열로 처리되는지

```
npx vitest run src/utils/__tests__/placeholderUtil.spec.ts
Test Files  1 passed (1)
     Tests  5 passed (5)

npm run check-types
(통과)
```