### PR TITLE
test: validateDDL 빈 입력·미닫힘 괄호 케이스 보강

### DIFF
--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -246,4 +246,13 @@ describe("validateDDL", () => {
 			`),
 		).toBe(false)
 	})
+
+	it("should reject empty or whitespace-only input", () => {
+		expect(validateDDL("")).toBe(false)
+		expect(validateDDL("   \n\t ")).toBe(false)
+	})
+
+	it("should reject statements with an unclosed parenthesis", () => {
+		expect(validateDDL("CREATE TABLE sample (id INT")).toBe(false)
+	})
 })

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -247,12 +247,16 @@ describe("validateDDL", () => {
 		).toBe(false)
 	})
 
-	it("should reject empty or whitespace-only input", () => {
+	it("should reject empty input", () => {
 		expect(validateDDL("")).toBe(false)
-		expect(validateDDL("   \n\t ")).toBe(false)
 	})
 
-	it("should reject statements with an unclosed parenthesis", () => {
+	it("should reject input that does not start with CREATE TABLE", () => {
+		expect(validateDDL("   \n\t ")).toBe(false)
+		expect(validateDDL("SELECT * FROM users")).toBe(false)
+	})
+
+	it("should reject CREATE TABLE with no closing parenthesis (statement extraction fails)", () => {
 		expect(validateDDL("CREATE TABLE sample (id INT")).toBe(false)
 	})
 })


### PR DESCRIPTION
## 배경

`src/shared/ddlParser.ts`의 `validateDDL`은 webview-ui vitest로 테스트되고 있으나, 다음 거부 분기들이 검증되지 않고 있었습니다.

- `if (!ddl)` — 빈 입력
- `if (!/^\s*CREATE\s+TABLE\s+/i.test(trimmedDDL))` (ddlParser.ts:236) — CREATE TABLE로 시작하지 않는 입력
- `if (!createTableStatement)` (ddlParser.ts:245) — 닫는 괄호가 없어 statement 추출이 실패하는 경우

## 변경

`webview-ui/src/utils/__tests__/ddlParser.spec.ts`에 위 세 분기를 각각 검증하는 테스트를 추가했습니다. 리뷰 의견을 반영해 한 테스트가 두 분기를 겸하지 않도록 분리했습니다.

- `should reject empty input` — `""`
- `should reject input that does not start with CREATE TABLE` — `"   \n\t "`, `"SELECT * FROM users"` (정규식 분기)
- `should reject CREATE TABLE with no closing parenthesis (statement extraction fails)` — `"CREATE TABLE sample (id INT"` (추출 실패 경로, ddlParser.ts:245)

테스트만 추가했고 동작 변경은 없습니다.

> 닫는 괄호 누락 케이스는 `extractCreateTableStatements`가 빈 배열을 반환해 `!createTableStatement`에서 먼저 거부되며, `openParens !== closeParens` 분기(추출문은 항상 괄호가 균형)에는 도달하지 않습니다. 해당 dead 분기 제거는 메인테이너 측 후속 작업으로 남겨둡니다.

## 검증

```
npx tsc -b            # EXIT 0
npx vitest run ddlParser.spec.ts
     Tests  16 passed (16)
```