### PR TITLE
fix: 컬럼 COMMENT의 'primary key' 문구로 인한 PK 오분류 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Code Generation
   - DDL 입력 내용을 기반으로 테이블, 컬럼, PK/FK, 1:N 관계를 표시하는 ERD Preview 추가
+  - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정
 - Project Generation
   - POM 생성 시 입력값(프로젝트명·groupId 등)에 `$`가 포함되면 `String.replace`의 치환 특수 시퀀스로 해석되어 pom.xml이 손상되던 문제 수정
 - Refactoring

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -190,8 +190,10 @@ export function parseDDL(ddl: string): ParsedDDL {
 		// 데이터 타입에서 크기 정보 제거
 		const dataType = RegExp(/^\w+/).exec(rawDataType)?.[0] ?? rawDataType
 
-		// PRIMARY KEY 확인
-		const isPrimaryKey = primaryKeyColumns.includes(columnName) || columnDef.toUpperCase().includes("PRIMARY KEY")
+		// PRIMARY KEY 확인 (COMMENT 문자열 본문은 제외해 'primary key' 문구가 든 주석의 오탐 방지)
+		const columnDefWithoutComment = columnDef.replace(/COMMENT\s+'(?:''|[^'])*'/i, "")
+		const isPrimaryKey =
+			primaryKeyColumns.includes(columnName) || columnDefWithoutComment.toUpperCase().includes("PRIMARY KEY")
 
 		// camelCase 이름 생성
 		const ccName = convertToCamelCase(columnName)

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -272,6 +272,24 @@ describe("ddlParser", () => {
 			["flag", "java.lang.Boolean"],
 		])
 	})
+
+	it("should not treat a column as primary key when only its comment mentions primary key", () => {
+		const result = parseDDL(`
+			CREATE TABLE notes (
+				id INT PRIMARY KEY,
+				note VARCHAR(200) COMMENT 'this is the primary key column'
+			);
+		`)
+
+		expect(result.pkAttributes).toHaveLength(1)
+		expect(result.pkAttributes[0].columnName).toBe("id")
+
+		const noteColumn = result.attributes.find((attribute) => attribute.columnName === "note")
+		expect(noteColumn?.isPrimaryKey).toBe(false)
+		expect(noteColumn?.comment).toBe("this is the primary key column")
+
+		expect(result.attributes[0].isPrimaryKey).toBe(true)
+	})
 })
 
 describe("validateDDL", () => {


### PR DESCRIPTION
## 변경 이유

`parseDDL`이 컬럼의 PRIMARY KEY 여부를 컬럼 정의 문자열 전체에서 판정합니다.

```js
const isPrimaryKey = primaryKeyColumns.includes(columnName) || columnDef.toUpperCase().includes("PRIMARY KEY")
```

`columnDef`에는 인라인 COMMENT 본문도 포함되므로, 컬럼 주석에 "primary key" 문구가 있으면 해당 컬럼이 PK로 잘못 분류됩니다.

예) `note VARCHAR(200) COMMENT 'this is the primary key column'` → `note`가 PK로 인식됨.

오분류된 컬럼이 `pkAttributes`에 들어가면 `sample-mapper-template.hbs`의 UPDATE/DELETE/SELECT WHERE 절이 잘못 생성됩니다.

## 변경 내용

PK 키워드 검사 전에 인라인 COMMENT 절을 제거한 문자열을 사용해, 주석 본문의 "primary key" 문구로 인한 오탐을 막습니다. 실제 인라인 PK 정의(`id INT PRIMARY KEY`)는 그대로 인식됩니다.

## 테스트 방법

`ddlParser.spec.ts`: 컬럼 COMMENT에 "primary key" 문구가 있어도 PK로 분류되지 않고, 실제 인라인 PK는 정상 인식됨을 검증합니다.

## 영향 범위

PK 판정 로직만 변경하며 정상 PK·일반 컬럼 처리에는 영향이 없습니다.
