### PR TITLE
fix: 컬럼명 언더스코어 뒤 숫자의 camelCase 변환 누락 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Code Generation
   - DDL 입력 내용을 기반으로 테이블, 컬럼, PK/FK, 1:N 관계를 표시하는 ERD Preview 추가
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정
+  - 컬럼명에서 언더스코어 뒤에 숫자가 오는 경우(addr_1 등) camelCase 변환이 누락되어 언더스코어가 남던 문제 수정
 - Project Generation
   - POM 생성 시 입력값(프로젝트명·groupId 등)에 `$`가 포함되면 `String.replace`의 치환 특수 시퀀스로 해석되어 pom.xml이 손상되던 문제 수정
 - Refactoring

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -27,7 +27,9 @@ export interface CreateTableStatement {
 
 // snake_case를 camelCase로 변환하는 함수
 function convertToCamelCase(str: string): string {
-	return str.toLowerCase().replace(/_([a-z])/g, (match, letter) => letter.toUpperCase())
+	// 언더스코어 뒤의 영문/숫자를 모두 처리한다. 숫자만 오는 경우(addr_1 등)에도
+	// 언더스코어를 제거해 addr1처럼 일관된 camelCase 식별자를 생성한다.
+	return str.toLowerCase().replace(/_([a-z0-9])/g, (match, ch) => ch.toUpperCase())
 }
 
 // camelCase를 PascalCase로 변환하는 함수

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -290,6 +290,28 @@ describe("ddlParser", () => {
 
 		expect(result.attributes[0].isPrimaryKey).toBe(true)
 	})
+
+	it("should convert underscore followed by a digit into a clean camelCase name", () => {
+		const result = parseDDL(`
+			CREATE TABLE addresses (
+				id INT PRIMARY KEY,
+				addr_1 VARCHAR(200),
+				zip_no_1 VARCHAR(10)
+			);
+		`)
+
+		const addr = result.attributes.find((attribute) => attribute.columnName === "addr_1")
+		expect(addr?.ccName).toBe("addr1")
+		expect(addr?.pcName).toBe("Addr1")
+
+		const zip = result.attributes.find((attribute) => attribute.columnName === "zip_no_1")
+		expect(zip?.ccName).toBe("zipNo1")
+		expect(zip?.pcName).toBe("ZipNo1")
+
+		// 기존 영문 변환 동작은 유지된다
+		const id = result.attributes.find((attribute) => attribute.columnName === "id")
+		expect(id?.ccName).toBe("id")
+	})
 })
 
 describe("validateDDL", () => {


### PR DESCRIPTION
## 변경 이유

`convertToCamelCase`의 정규식이 언더스코어 뒤 영문자만 처리합니다.

```js
str.toLowerCase().replace(/_([a-z])/g, (match, letter) => letter.toUpperCase())
```

언더스코어 뒤에 숫자가 오면 매칭되지 않아 변환이 누락됩니다.

- `addr_1` → `addr_1` (언더스코어 잔존)
- `zip_no_1` → `zipNo_1` (혼합)

이 값이 MyBatis property·VO 필드명(`ccName`)과 getter(`pcName`)에 그대로 전파됩니다.

## 변경 내용

패턴을 `/_([a-z0-9])/g`로 넓혀 언더스코어 뒤 숫자도 처리합니다.

- `addr_1` → `addr1`
- `zip_no_1` → `zipNo1`

기존 영문 변환(`user_name` → `userName`)은 그대로 유지됩니다.

## 테스트 방법

`ddlParser.spec.ts`: `addr_1` → `addr1`, `zip_no_1` → `zipNo1`로 변환되고 기존 영문 케이스가 회귀하지 않음을 검증합니다.

## 영향 범위

snake_case → camelCase 변환만 정정하며 컬럼명에 숫자 접미가 없는 경우 동작은 동일합니다.
