### PR TITLE
fix: Group ID 검증이 연속된 점·숫자 시작 세그먼트를 허용하는 문제 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - 컬럼명에서 언더스코어 뒤에 숫자가 오는 경우(addr_1 등) camelCase 변환이 누락되어 언더스코어가 남던 문제 수정
 - Project Generation
   - POM 생성 시 입력값(프로젝트명·groupId 등)에 `$`가 포함되면 `String.replace`의 치환 특수 시퀀스로 해석되어 pom.xml이 손상되던 문제 수정
+  - Group ID 검증이 연속된 점(com..example)과 숫자로 시작하는 세그먼트(com.123)를 허용해 잘못된 Maven groupId가 생성되던 문제 수정
 - Refactoring
   - 불필요한 try/catch(no-useless-catch) 제거 (codeGenerator.ts)
 

--- a/webview-ui/src/utils/__tests__/projectUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/projectUtils.spec.ts
@@ -9,6 +9,9 @@ const makeTemplate = (overrides: Partial<ProjectTemplate> = {}): ProjectTemplate
 	...overrides,
 })
 
+const groupIdError =
+	"Group ID must consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers"
+
 describe("validateProjectConfig", () => {
 	it("projectName이 없으면 오류를 반환한다", () => {
 		const errors = validateProjectConfig({
@@ -72,7 +75,7 @@ describe("validateProjectConfig", () => {
 			groupId: "Invalid.Group",
 			artifactId: "my-project",
 		})
-		expect(errors.some((e) => e.includes("Group ID must start"))).toBe(true)
+		expect(errors).toContain(groupIdError)
 	})
 
 	it("groupId가 점으로 끝나면 오류를 반환한다", () => {
@@ -83,7 +86,53 @@ describe("validateProjectConfig", () => {
 			groupId: "egovframework.",
 			artifactId: "my-project",
 		})
-		expect(errors.some((e) => e.includes("Group ID must start"))).toBe(true)
+		expect(errors).toContain(groupIdError)
+	})
+
+	it("groupId 세그먼트가 소문자/숫자 규칙을 지키면 통과한다", () => {
+		for (const groupId of ["com.example", "org.egovframe.test", "a.b", "org.egovframe", "com.example2"]) {
+			const errors = validateProjectConfig({
+				projectName: "my-project",
+				template: makeTemplate({ pomFile: "pom.xml" }),
+				outputPath: "/tmp",
+				groupId,
+				artifactId: "my-project",
+			})
+			expect(errors, `expected no groupId error for "${groupId}"`).not.toContain(groupIdError)
+		}
+	})
+
+	it("연속된 점(빈 세그먼트)이 있으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "com..example",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain(groupIdError)
+	})
+
+	it("숫자로 시작하는 세그먼트가 있으면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: "com.123",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain(groupIdError)
+	})
+
+	it("점으로 시작하면 오류를 반환한다", () => {
+		const errors = validateProjectConfig({
+			projectName: "my-project",
+			template: makeTemplate({ pomFile: "pom.xml" }),
+			outputPath: "/tmp",
+			groupId: ".com",
+			artifactId: "my-project",
+		})
+		expect(errors).toContain(groupIdError)
 	})
 
 	it("pomFile이 있는 템플릿에서 artifactId가 없으면 오류를 반환한다", () => {
@@ -113,9 +162,11 @@ describe("validateProjectConfig", () => {
 			projectName: "my-project",
 			template: makeTemplate({ pomFile: "" }),
 			outputPath: "/tmp",
+			groupId: "com..example",
 		})
 		expect(errors).not.toContain("Group ID is required for this template")
 		expect(errors).not.toContain("Artifact ID is required for this template")
+		expect(errors).not.toContain(groupIdError)
 	})
 
 	it("모든 필드가 유효하면 빈 배열을 반환한다", () => {

--- a/webview-ui/src/utils/projectUtils.ts
+++ b/webview-ui/src/utils/projectUtils.ts
@@ -66,9 +66,9 @@ export function validateProjectConfig(config: Partial<ProjectConfig>): string[] 
 	if (config.template?.pomFile) {
 		if (!config.groupId || config.groupId.trim() === "") {
 			errors.push("Group ID is required for this template")
-		} else if (!/^[a-z]([a-z0-9.]*[a-z0-9])?$/.test(config.groupId)) {
+		} else if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(config.groupId)) {
 			errors.push(
-				"Group ID must start with a lowercase letter, contain only lowercase letters, numbers, or dots, and cannot end with a dot",
+				"Group ID must consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
 			)
 		}
 	}


### PR DESCRIPTION
## 변경 이유

`validateProjectConfig`의 Group ID 검증 정규식이 세그먼트 단위 규칙을 강제하지 않습니다.

```
/^[a-z]([a-z0-9.]*[a-z0-9])?$/
```

점의 위치에 제약이 없어 연속된 점(`com..example`, 빈 세그먼트)과 숫자로 시작하는 세그먼트(`com.123`)를 모두 통과시킵니다. 이 Group ID는 `generatePomFile`에서 `###GROUP_ID###` 자리에 치환되어 pom.xml에 그대로 들어가므로, 잘못된 Maven groupId(겸 Java 패키지명)가 생성됩니다.

## 변경 내용

- 정규식을 세그먼트 단위 검증으로 교정했습니다.

  ```
  /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/
  ```

  각 세그먼트는 소문자로 시작하고 소문자·숫자만 포함하며 점으로 구분됩니다. 빈 세그먼트·숫자로 시작하는 세그먼트·연속된 점·앞뒤 점을 모두 거부합니다. 기존에 통과하던 `com.example`·`org.egovframe.test` 등은 그대로 유효합니다.
- 검증 실패 안내 문구도 새 규칙에 맞게 정정했습니다. Artifact ID 검증은 건드리지 않았습니다.

## 테스트 방법

`webview-ui/src/utils/__tests__/projectUtils.spec.ts`(vitest 11건):
- 유효(`com.example`·`org.egovframe.test` 등)는 오류 없음
- 무효(`com..example`·`com.123`·`.com`·`com.`·`Com.example`)는 Group ID 오류 포함
- pomFile 없는 템플릿은 Group ID를 검증하지 않음

변경 전에는 `com..example`·`com.123`이 통과해 이 테스트가 실패하고, 변경 후 거부됩니다.

## 영향 범위

Group ID 형식 검증만 바뀌며, 기존 유효 Group ID의 동작은 동일합니다.
