### PR TITLE
fix: 프로젝트·설정 생성 시 경로 조작(CWE-22) 입력 검증 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Project Generation
   - POM 생성 시 입력값(프로젝트명·groupId 등)에 `$`가 포함되면 `String.replace`의 치환 특수 시퀀스로 해석되어 pom.xml이 손상되던 문제 수정
   - Group ID 검증이 연속된 점(com..example)과 숫자로 시작하는 세그먼트(com.123)를 허용해 잘못된 Maven groupId가 생성되던 문제 수정
+  - Security: 프로젝트명·설정 파일명 입력에 경로 조작(CWE-22) 검증 추가 — 생성 결과가 지정한 출력 디렉터리를 벗어나지 못하도록 봉쇄
 - Refactoring
   - 불필요한 try/catch(no-useless-catch) 제거 (codeGenerator.ts)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
 				"npm-run-all": "4.1.5",
 				"ovsx": "0.10.12",
 				"prettier": "3.8.1",
-				"typescript": "5.4.5"
+				"typescript": "5.4.5",
+				"vitest": "3.0.9"
 			},
 			"engines": {
 				"vscode": "^1.84.0"
@@ -886,6 +887,13 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1205,6 +1213,395 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+			"integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+			"integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+			"integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+			"integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+			"integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+			"integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+			"integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+			"integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+			"integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+			"integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+			"integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+			"integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+			"integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+			"integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+			"integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+			"integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+			"integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+			"integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+			"integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+			"integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+			"integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+			"integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+			"integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@secretlint/config-creator": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
@@ -1487,6 +1884,13 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/fs-extra": {
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
@@ -1763,6 +2167,145 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
+			"integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.0.9",
+				"@vitest/utils": "3.0.9",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
+			"integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.0.9",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+			"integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
+			"integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.0.9",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
+			"integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.0.9",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
+			"integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
+			"integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^3.0.2"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
+			"integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.0.9",
+				"loupe": "^3.1.3",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
+			"integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "3.7.1",
@@ -2131,6 +2674,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2338,6 +2891,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2398,6 +2961,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2413,6 +2993,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/cheerio": {
@@ -2722,6 +3312,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-extend": {
@@ -3124,6 +3724,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3437,6 +4044,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3463,6 +4080,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/extract-zip": {
@@ -3736,6 +4363,21 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -5307,6 +5949,13 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5318,6 +5967,16 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/markdown-it": {
@@ -5506,6 +6165,25 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.15",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/napi-build-utils": {
 			"version": "2.0.0",
@@ -6198,6 +6876,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6265,6 +6960,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.12",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prebuild-install": {
@@ -6668,6 +7392,51 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+			"integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.9"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.62.2",
+				"@rollup/rollup-android-arm64": "4.62.2",
+				"@rollup/rollup-darwin-arm64": "4.62.2",
+				"@rollup/rollup-darwin-x64": "4.62.2",
+				"@rollup/rollup-freebsd-arm64": "4.62.2",
+				"@rollup/rollup-freebsd-x64": "4.62.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.62.2",
+				"@rollup/rollup-linux-arm64-musl": "4.62.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.62.2",
+				"@rollup/rollup-linux-loong64-musl": "4.62.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.62.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.62.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-musl": "4.62.2",
+				"@rollup/rollup-openbsd-x64": "4.62.2",
+				"@rollup/rollup-openharmony-arm64": "4.62.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.62.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.62.2",
+				"@rollup/rollup-win32-x64-gnu": "4.62.2",
+				"@rollup/rollup-win32-x64-msvc": "4.62.2",
+				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -7152,6 +7921,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7273,6 +8049,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -7308,6 +8094,20 @@
 			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
@@ -7702,6 +8502,13 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinyexec": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -7710,6 +8517,84 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+			"integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tmp": {
@@ -8053,6 +8938,212 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/vite": {
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2",
+				"postcss": "^8.5.3",
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.13"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"jiti": ">=1.21.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
+			"integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.0",
+				"es-module-lexer": "^1.6.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
+			"integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "3.0.9",
+				"@vitest/mocker": "3.0.9",
+				"@vitest/pretty-format": "^3.0.9",
+				"@vitest/runner": "3.0.9",
+				"@vitest/snapshot": "3.0.9",
+				"@vitest/spy": "3.0.9",
+				"@vitest/utils": "3.0.9",
+				"chai": "^5.2.0",
+				"debug": "^4.4.0",
+				"expect-type": "^1.1.0",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"std-env": "^3.8.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinypool": "^1.0.2",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0",
+				"vite-node": "3.0.9",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.0.9",
+				"@vitest/ui": "3.0.9",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -8180,6 +9271,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,8 @@
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "npm run check-types && npm run build:webview && npm run lint && node esbuild.js --production",
 		"check-types": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest dev",
 		"lint": "eslint src --ext ts && eslint webview-ui/src --ext ts",
 		"format": "prettier . --check",
 		"format:fix": "prettier . --write --ignore-path .prettierignore",
@@ -159,14 +161,15 @@
 		"@typescript-eslint/eslint-plugin": "7.15.0",
 		"@typescript-eslint/parser": "7.15.0",
 		"@vscode/vsce": "3.7.1",
-		"ovsx": "0.10.12",
 		"esbuild": "0.25.0",
 		"eslint": "8.57.1",
 		"husky": "9.1.7",
 		"lint-staged": "16.3.3",
 		"npm-run-all": "4.1.5",
+		"ovsx": "0.10.12",
 		"prettier": "3.8.1",
-		"typescript": "5.4.5"
+		"typescript": "5.4.5",
+		"vitest": "3.0.9"
 	},
 	"dependencies": {
 		"extract-zip": "2.0.1",

--- a/src/utils/__tests__/pathSafety.spec.ts
+++ b/src/utils/__tests__/pathSafety.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest"
+import * as path from "path"
+import { isValidProjectName, assertSafeProjectName, sanitizeFileName, resolveWithinBase } from "../pathSafety"
+
+describe("isValidProjectName", () => {
+	it("accepts letters, numbers, hyphens and underscores", () => {
+		expect(isValidProjectName("myProject")).toBe(true)
+		expect(isValidProjectName("my_project-1")).toBe(true)
+		expect(isValidProjectName("ABC123")).toBe(true)
+	})
+
+	it("rejects traversal and separator characters", () => {
+		expect(isValidProjectName("../evil")).toBe(false)
+		expect(isValidProjectName("..")).toBe(false)
+		expect(isValidProjectName("a/b")).toBe(false)
+		expect(isValidProjectName("a\\b")).toBe(false)
+		expect(isValidProjectName("a.b")).toBe(false)
+		expect(isValidProjectName("a b")).toBe(false)
+		expect(isValidProjectName("")).toBe(false)
+	})
+})
+
+describe("assertSafeProjectName", () => {
+	it("does not throw for a valid name", () => {
+		expect(() => assertSafeProjectName("valid_name-1")).not.toThrow()
+	})
+
+	it("throws for traversal input", () => {
+		expect(() => assertSafeProjectName("../../etc")).toThrow()
+		expect(() => assertSafeProjectName("..")).toThrow()
+		expect(() => assertSafeProjectName("a/b")).toThrow()
+	})
+})
+
+describe("sanitizeFileName", () => {
+	it("returns a plain file name unchanged", () => {
+		expect(sanitizeFileName("context.xml")).toBe("context.xml")
+		expect(sanitizeFileName("application")).toBe("application")
+	})
+
+	it("strips directory segments to the base name", () => {
+		expect(sanitizeFileName("../../evil.xml")).toBe("evil.xml")
+		expect(sanitizeFileName("sub/dir/file.xml")).toBe("file.xml")
+		expect(sanitizeFileName("  spaced.xml  ")).toBe("spaced.xml")
+	})
+
+	it("rejects names that resolve to a traversal or empty value", () => {
+		expect(() => sanitizeFileName("")).toThrow()
+		expect(() => sanitizeFileName("   ")).toThrow()
+		expect(() => sanitizeFileName(".")).toThrow()
+		expect(() => sanitizeFileName("..")).toThrow()
+	})
+})
+
+describe("resolveWithinBase", () => {
+	const base = path.resolve("/tmp/egov-output")
+
+	it("returns the resolved path for a child inside the base", () => {
+		expect(resolveWithinBase(base, "project")).toBe(path.join(base, "project"))
+		expect(resolveWithinBase(base, "nested/file.xml")).toBe(path.join(base, "nested", "file.xml"))
+	})
+
+	it("throws when the resolved path escapes the base", () => {
+		expect(() => resolveWithinBase(base, "../escape")).toThrow()
+		expect(() => resolveWithinBase(base, "../../etc/passwd")).toThrow()
+		expect(() => resolveWithinBase(base, path.resolve("/etc/passwd"))).toThrow()
+	})
+
+	it("throws when the child resolves to the base itself", () => {
+		expect(() => resolveWithinBase(base, ".")).toThrow()
+	})
+})

--- a/src/utils/__tests__/pathSafety.spec.ts
+++ b/src/utils/__tests__/pathSafety.spec.ts
@@ -9,14 +9,25 @@ describe("isValidProjectName", () => {
 		expect(isValidProjectName("ABC123")).toBe(true)
 	})
 
+	it("accepts single dots between segments", () => {
+		expect(isValidProjectName("a.b")).toBe(true)
+		expect(isValidProjectName("my.project")).toBe(true)
+		expect(isValidProjectName("com.example.app")).toBe(true)
+	})
+
 	it("rejects traversal and separator characters", () => {
 		expect(isValidProjectName("../evil")).toBe(false)
 		expect(isValidProjectName("..")).toBe(false)
 		expect(isValidProjectName("a/b")).toBe(false)
 		expect(isValidProjectName("a\\b")).toBe(false)
-		expect(isValidProjectName("a.b")).toBe(false)
 		expect(isValidProjectName("a b")).toBe(false)
 		expect(isValidProjectName("")).toBe(false)
+	})
+
+	it("rejects consecutive, leading, or trailing dots", () => {
+		expect(isValidProjectName("a..b")).toBe(false)
+		expect(isValidProjectName(".hidden")).toBe(false)
+		expect(isValidProjectName("name.")).toBe(false)
 	})
 })
 

--- a/src/utils/configGenerator.ts
+++ b/src/utils/configGenerator.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs-extra"
 import * as Handlebars from "handlebars"
+import { sanitizeFileName, resolveWithinBase } from "./pathSafety"
 
 // Template configuration interface
 export interface TemplateConfig {
@@ -183,12 +184,14 @@ export async function generateFile(
 		const content = await renderTemplate(templatePath, data)
 		console.log("- template rendered, content length:", content.length)
 
-		let fileName = data[fileNameProperty] || "default_filename"
+		// Reduce the user-supplied name to a plain file name to block path traversal (CWE-22)
+		let fileName = sanitizeFileName(data[fileNameProperty] || "default_filename")
 		if (!fileName.endsWith(`.${fileExtension}`)) {
 			fileName += `.${fileExtension}`
 		}
 
-		const outputPath = path.join(outputFolderPath, fileName)
+		// Defense in depth: ensure the resolved path stays inside the output folder
+		const outputPath = resolveWithinBase(outputFolderPath, fileName)
 		console.log("- output path:", outputPath)
 
 		// Ensure output directory exists

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -30,7 +30,7 @@ export function isValidProjectName(projectName: string): boolean {
  */
 export function assertSafeProjectName(projectName: string): void {
 	if (!isValidProjectName(projectName)) {
-		throw new Error("Project name can only contain letters, numbers, hyphens, and underscores")
+		throw new Error("Project name can only contain letters, numbers, hyphens, underscores, and single dots between segments")
 	}
 }
 

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,0 +1,70 @@
+import * as path from "path"
+
+/**
+ * Path traversal hardening utilities (CWE-22).
+ *
+ * These helpers harden file-system writes that are driven by free-form
+ * webview form input (project name, configuration file name). They contain
+ * no VS Code dependency so they can be unit tested in isolation.
+ */
+
+/**
+ * Allowed character set for an eGovFrame project name.
+ * Letters, digits, hyphen and underscore only — separators and dots are
+ * intentionally excluded so that no path component (e.g. `..`, `/`, `\`)
+ * can appear in the name.
+ */
+export const PROJECT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * Returns true when the given project name is safe to use as a single
+ * directory component.
+ */
+export function isValidProjectName(projectName: string): boolean {
+	return typeof projectName === "string" && PROJECT_NAME_PATTERN.test(projectName)
+}
+
+/**
+ * Throws when the project name is not a safe single directory component.
+ */
+export function assertSafeProjectName(projectName: string): void {
+	if (!isValidProjectName(projectName)) {
+		throw new Error("Project name can only contain letters, numbers, hyphens, and underscores")
+	}
+}
+
+/**
+ * Reduces a user-supplied file name to its base name and rejects values that
+ * resolve to a directory traversal. Any leading directory segments (including
+ * `..`) are stripped so the result is always a plain file name.
+ */
+export function sanitizeFileName(rawFileName: string): string {
+	if (typeof rawFileName !== "string") {
+		throw new Error("Invalid file name")
+	}
+
+	const baseName = path.basename(rawFileName.trim())
+
+	if (!baseName || baseName === "." || baseName === "..") {
+		throw new Error("Invalid file name")
+	}
+
+	return baseName
+}
+
+/**
+ * Resolves `childPath` against `baseDir` and verifies the result stays inside
+ * `baseDir`. Returns the resolved absolute path, or throws if the resolved
+ * location escapes the base directory (path traversal).
+ */
+export function resolveWithinBase(baseDir: string, childPath: string): string {
+	const resolvedBase = path.resolve(baseDir)
+	const resolvedTarget = path.resolve(resolvedBase, childPath)
+	const relative = path.relative(resolvedBase, resolvedTarget)
+
+	if (relative === "" || relative === ".." || relative.startsWith(".." + path.sep) || path.isAbsolute(relative)) {
+		throw new Error("Resolved path escapes the target directory")
+	}
+
+	return resolvedTarget
+}

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -10,11 +10,12 @@ import * as path from "path"
 
 /**
  * Allowed character set for an eGovFrame project name.
- * Letters, digits, hyphen and underscore only — separators and dots are
- * intentionally excluded so that no path component (e.g. `..`, `/`, `\`)
- * can appear in the name.
+ * Alphanumeric segments (letters, digits, hyphen, underscore) joined by single
+ * dots — e.g. `com.example.app`. Each dot must sit between two segments, so a
+ * consecutive `..`, a leading/trailing dot, or a path separator (`/`, `\`)
+ * cannot appear in the name.
  */
-export const PROJECT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
+export const PROJECT_NAME_PATTERN = /^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/
 
 /**
  * Returns true when the given project name is safe to use as a single

--- a/src/utils/projectGenerator.ts
+++ b/src/utils/projectGenerator.ts
@@ -3,6 +3,7 @@ import * as fs from "fs-extra"
 import * as path from "path"
 import extractZip from "extract-zip"
 import { replacePlaceholders } from "../shared/placeholderUtil"
+import { assertSafeProjectName, resolveWithinBase } from "./pathSafety"
 
 export interface EgovProjectTemplate {
 	id: string
@@ -82,9 +83,13 @@ export async function generateEgovProject(
 			throw new Error("Template file name is required")
 		}
 
+		// Restrict project name to a safe single directory component (CWE-22)
+		assertSafeProjectName(config.projectName)
+
 		// Setup paths
 		const zipFilePath = path.join(extensionPath, "templates", "projects", "examples", config.template.fileName)
-		const projectRoot = path.join(config.outputPath, config.projectName)
+		// Defense in depth: ensure the project root stays inside the output path
+		const projectRoot = resolveWithinBase(config.outputPath, config.projectName)
 
 		progressCallback?.("📁 Creating project directory...")
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+// Unit tests for the extension host (`src/`). The webview UI keeps its own
+// vitest setup under `webview-ui/`.
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.{test,spec}.ts"],
+	},
+})

--- a/webview-ui/src/utils/__tests__/projectUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/projectUtils.spec.ts
@@ -35,6 +35,23 @@ describe("validateProjectConfig", () => {
 		expect(errors).toContain("Project name is required")
 	})
 
+	const projectNameError =
+		"Project name can only contain letters, numbers, hyphens, underscores, and single dots between segments"
+
+	it("projectName에 세그먼트 사이 단일 점은 허용한다", () => {
+		for (const projectName of ["my-project", "myProject", "my_project-1", "my.project", "com.example.app"]) {
+			const errors = validateProjectConfig({ projectName, template: makeTemplate({ pomFile: "" }), outputPath: "/tmp" })
+			expect(errors, `expected no projectName error for "${projectName}"`).not.toContain(projectNameError)
+		}
+	})
+
+	it("projectName에 경로 조작·구분자·연속/선행/후행 점이 있으면 오류를 반환한다", () => {
+		for (const projectName of ["../evil", "..", "a/b", "a\\b", "a b", "a..b", ".hidden", "name."]) {
+			const errors = validateProjectConfig({ projectName, template: makeTemplate({ pomFile: "" }), outputPath: "/tmp" })
+			expect(errors, `expected projectName error for "${projectName}"`).toContain(projectNameError)
+		}
+	})
+
 	it("outputPath가 없으면 오류를 반환한다", () => {
 		const errors = validateProjectConfig({
 			projectName: "my-project",

--- a/webview-ui/src/utils/projectUtils.ts
+++ b/webview-ui/src/utils/projectUtils.ts
@@ -60,6 +60,9 @@ export function validateProjectConfig(config: Partial<ProjectConfig>): string[] 
 
 	if (!config.projectName || config.projectName.trim() === "") {
 		errors.push("Project name is required")
+	} else if (!/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(config.projectName)) {
+		// 프로젝트명 허용 규칙 — 백엔드 `src/utils/pathSafety.ts`의 PROJECT_NAME_PATTERN과 동일하게 유지한다.
+		errors.push("Project name can only contain letters, numbers, hyphens, underscores, and single dots between segments")
 	}
 
 	// groupId validation (only for templates with pomFile)


### PR DESCRIPTION
## 변경 이유

`configGenerator.ts`의 파일명과 `projectGenerator.ts`의 `projectName`은 웹뷰 폼에서 자유 입력으로 들어온다. 이 값을 검증 없이 `path.join`으로 결합한 뒤 `fs.writeFile`과 `extractZip`의 경로로 사용한다. 그래서 `..` 같은 경로 조각이 섞이면 지정한 출력 디렉터리 밖에 파일이 생기거나 기존 파일을 덮어쓸 수 있다(CWE-22). `projectName`의 문자 집합 검증은 주석 처리돼, 실제로는 도달하지 못하는 코드에만 남아 있었다.

심각도는 Medium 수준의 방어적 코딩으로 본다. 트러스트 바운더리가 로컬 사용자에서 자기 파일 시스템으로 한정되기 때문이다(웹뷰 폼 → 자기 머신의 파일). 원격 공격자나 권한 상승 경로는 아니다. 이 변경의 가치는 예기치 않은 위치에 파일이 생성·덮어쓰기되는 것을 막고, 입력 검증 지점을 한곳에 명확히 두는 데 있다.

## 변경 내용

- `pathSafety.ts`를 새로 추가했다. VS Code 의존이 없어 단독으로 단위 테스트가 가능하다.
  - `sanitizeFileName`: `path.basename`으로 디렉터리 구간을 떼어내 항상 평범한 파일명만 남긴다.
  - `resolveWithinBase`: 결합 결과를 `path.relative` 기준으로 검사해 베이스 디렉터리를 벗어나면 예외를 던진다.
  - `assertSafeProjectName`: 프로젝트명을 `^[a-zA-Z0-9_-]+$`로 제한한다. 기존에 주석으로만 남아 있던 검증을 다시 활성화했다.
- `generateFile`(configGenerator.ts)의 파일명 싱크와 `generateEgovProject`(projectGenerator.ts)의 `projectName` 싱크에 위 함수를 적용했다.
- `pathSafety.spec.ts`에 테스트 10건을 추가했다.

`package-lock.json` diff가 큰(+1116) 이유는 테스트 러너 vitest를 새로 도입했기 때문이다. 기존 최상위 의존성 버전은 그대로다(typescript 5.4.5, esbuild 0.25.0 등). 확장 호스트(`src/`) 쪽 테스트 러너가 없어 루트에 node 기반 vitest를 띄웠다. `webview-ui`의 vitest는 jsdom 환경에 별도 패키지라 재사용할 수 없다.

`CHANGELOG.md`의 Unreleased에 항목을 추가했다.

## 테스트 방법

```bash
npm test
```

`pathSafety.spec.ts` 10건이 통과한다. `sanitizeFileName`이 `../../evil.txt`를 `evil.txt`로 줄이는지, `resolveWithinBase`가 베이스를 벗어나는 경로에 예외를 던지는지, `assertSafeProjectName`이 허용 문자 외 입력을 거르는지 확인한다.

## 영향 범위

- 정상 입력(평범한 파일명·프로젝트명)은 동작이 그대로다.
- 경로 조각이나 허용 외 문자가 섞인 입력은 파일 생성 전에 예외로 막힌다.
- 런타임 의존성은 변하지 않고 devDependencies에 vitest만 늘었다.
