### PR TITLE
fix: ERD Preview에서 컬럼 COMMENT 문구로 인한 PK·FK 오분류 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락된 SQL 타입 보강 (Refs: PR #19)
   - TEXT/BLOB/BYTE 타입을 각각 String/byte[]/byte[]로 변환하도록 매핑 추가 (Refs: PR #16)
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
+  - ERD Preview에서 컬럼 COMMENT 본문의 "primary key"·"references" 문구를 제약조건으로 오인해 PK/FK가 잘못 표시되던 문제 수정
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락된 SQL 타입 보강 (Refs: PR #19)
   - TEXT/BLOB/BYTE 타입을 각각 String/byte[]/byte[]로 변환하도록 매핑 추가 (Refs: PR #16)
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
-  - ERD Preview에서 컬럼 COMMENT 본문의 "primary key"·"references" 문구를 제약조건으로 오인해 PK/FK가 잘못 표시되던 문제 수정
+  - ERD Preview에서 컬럼 COMMENT 본문의 "primary key"·"references" 문구를 제약조건으로 오인해 PK/FK가 잘못 표시되던 문제 수정 (Refs: PR #33)
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/src/shared/erdParser.ts
+++ b/src/shared/erdParser.ts
@@ -43,6 +43,13 @@ function getDefinitionKind(definition: string): string {
 	return definition.split(/\s+/)[0]?.toUpperCase() || ""
 }
 
+// 제약조건 판정에 쓰지 않을 COMMENT 문자열 본문을 걷어낸다.
+// 주석에 든 'primary key'·'references' 문구를 제약조건으로 오인하지 않기 위한 것으로,
+// ddlParser의 PK 판정과 같은 규칙을 쓴다.
+function stripColumnComment(definition: string): string {
+	return definition.replace(/COMMENT\s+'(?:''|[^'])*'/i, "")
+}
+
 export function parseErdModel(ddl: string): ErdModel {
 	const createTableStatements = extractCreateTableStatements(ddl)
 	const tables: ErdTable[] = []
@@ -56,13 +63,16 @@ export function parseErdModel(ddl: string): ErdModel {
 		const columns: ErdColumn[] = []
 
 		for (const definition of definitions) {
-			const pkMatch = /PRIMARY\s+KEY\s*\(([^)]+)\)/i.exec(definition)
+			const definitionWithoutComment = stripColumnComment(definition)
+			const pkMatch = /PRIMARY\s+KEY\s*\(([^)]+)\)/i.exec(definitionWithoutComment)
 			if (pkMatch) {
 				parseColumnList(pkMatch[1]).forEach((columnName) => primaryKeyColumns.add(columnName))
 				continue
 			}
 
-			const fkMatch = /FOREIGN\s+KEY\s*\(([^)]+)\)\s+REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(definition)
+			const fkMatch = /FOREIGN\s+KEY\s*\(([^)]+)\)\s+REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(
+				definitionWithoutComment,
+			)
 			if (fkMatch) {
 				const fromColumns = parseColumnList(fkMatch[1])
 				const toTable = cleanIdentifier(fkMatch[2])
@@ -95,7 +105,8 @@ export function parseErdModel(ddl: string): ErdModel {
 				continue
 			}
 
-			const inlineReferenceMatch = /REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(definition)
+			const definitionWithoutComment = stripColumnComment(definition)
+			const inlineReferenceMatch = /REFERENCES\s+[`"]?(\w+)[`"]?\s*\(([^)]+)\)/i.exec(definitionWithoutComment)
 			if (inlineReferenceMatch) {
 				const toTable = cleanIdentifier(inlineReferenceMatch[1])
 				const toColumn = parseColumnList(inlineReferenceMatch[2])[0] || "id"
@@ -111,7 +122,7 @@ export function parseErdModel(ddl: string): ErdModel {
 			columns.push({
 				name: columnName,
 				dataType,
-				isPrimaryKey: primaryKeyColumns.has(columnName) || /\bPRIMARY\s+KEY\b/i.test(definition),
+				isPrimaryKey: primaryKeyColumns.has(columnName) || /\bPRIMARY\s+KEY\b/i.test(definitionWithoutComment),
 				isForeignKey: foreignKeyColumns.has(columnName),
 			})
 		}

--- a/webview-ui/src/utils/__tests__/erdParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/erdParser.spec.ts
@@ -50,4 +50,46 @@ describe("parseErdModel", () => {
 			},
 		])
 	})
+
+	it("does not mark a column as primary key when only its comment mentions primary key", () => {
+		const model = parseErdModel(`
+			CREATE TABLE notes (
+				id INT PRIMARY KEY,
+				memo VARCHAR(100) COMMENT 'not the primary key just a note'
+			);
+		`)
+
+		const columns = model.tables[0].columns
+		expect(columns.map((column) => column.name)).toEqual(["id", "memo"])
+		expect(columns.find((column) => column.name === "id")?.isPrimaryKey).toBe(true)
+		expect(columns.find((column) => column.name === "memo")?.isPrimaryKey).toBe(false)
+	})
+
+	it("does not read a table-level primary key constraint out of a column comment", () => {
+		const model = parseErdModel(`
+			CREATE TABLE notes (
+				id INT,
+				memo VARCHAR(100) COMMENT 'see primary key (id) for details',
+				PRIMARY KEY (id)
+			);
+		`)
+
+		const columns = model.tables[0].columns
+		expect(columns.map((column) => column.name)).toEqual(["id", "memo"])
+		expect(columns.find((column) => column.name === "memo")?.isPrimaryKey).toBe(false)
+	})
+
+	it("does not read a foreign key constraint out of a column comment", () => {
+		const model = parseErdModel(`
+			CREATE TABLE notes (
+				id INT PRIMARY KEY,
+				memo VARCHAR(100) COMMENT 'foreign key (id) references users(id) is defined elsewhere'
+			);
+		`)
+
+		const columns = model.tables[0].columns
+		expect(columns.map((column) => column.name)).toEqual(["id", "memo"])
+		expect(columns.find((column) => column.name === "memo")?.isForeignKey).toBe(false)
+		expect(model.relationships).toEqual([])
+	})
 })


### PR DESCRIPTION
## 변경 이유

`parseErdModel`이 컬럼의 제약조건을 컬럼 정의 문자열 전체에서 판정합니다.

```ts
isPrimaryKey: primaryKeyColumns.has(columnName) || /\bPRIMARY\s+KEY\b/i.test(definition),
```

`definition`에는 인라인 COMMENT 본문도 들어 있어서 주석에 "primary key"나 "references" 문구가 있으면 그 문구가 제약조건으로 잡힙니다.

예) 아래 DDL의 `memo`가 ERD에서 PK로 표시됩니다.

```sql
CREATE TABLE notes (
  id INT PRIMARY KEY,
  memo VARCHAR(100) COMMENT 'not the primary key just a note'
);
```

같은 DDL을 `parseDDL`에 넣으면 `memo`의 `isPrimaryKey`는 false입니다. PR #27이 COMMENT 본문 제외를 `ddlParser`에만 적용했으므로 코드 생성 쪽 오탐은 사라졌지만 ERD Preview에는 그대로 남았습니다. 같은 DDL을 놓고 두 화면이 서로 다른 키 구성을 보여주는 상태입니다.

FK도 같습니다. COMMENT 본문의 `references users(id)` 문구가 인라인 참조로 잡혀서 실제로 없는 관계선이 ERD에 그려집니다.

## 변경 내용

- COMMENT 문자열 본문을 걷어내는 `stripColumnComment` 헬퍼를 추가했습니다. PK·FK·인라인 REFERENCES 판정은 그 결과 문자열로 수행합니다. 정규식은 PR #27이 적용한 `src/shared/ddlParser.ts`의 PK 판정과 동일합니다.

  ```ts
  definition.replace(/COMMENT\s+'(?:''|[^'])*'/i, "")
  ```

- 컬럼명·데이터 타입 추출과 테이블 레벨 제약조건 건너뛰기 판정은 원래 문자열을 그대로 씁니다. 기존 동작은 바뀌지 않습니다.

## 테스트 방법

`webview-ui/src/utils/__tests__/erdParser.spec.ts`에 vitest 3건을 추가했습니다.

- COMMENT 본문에 "primary key"가 있는 컬럼은 PK로 표시되지 않고 같은 테이블의 실제 인라인 PK(`id INT PRIMARY KEY`)는 그대로 인식됩니다.
- COMMENT 본문의 `primary key (id)` 문구를 테이블 레벨 제약조건으로 읽지 않습니다.
- COMMENT 본문의 `foreign key (id) references users(id)` 문구로는 FK 표시도 관계선도 생기지 않습니다(`relationships`가 빈 배열).

`src/shared/erdParser.ts`만 변경 전으로 되돌리면 이 3건이 모두 실패합니다.

전체 검증 결과는 다음과 같습니다.

- `npm run check-types` 오류 없음
- `npm run lint` 오류 없음
- `npm run format` 통과
- `npx vitest run` 30건 통과, `cd webview-ui && npx vitest run` 95건 통과

## 영향 범위

ERD Preview의 제약조건 판정만 바뀝니다. COMMENT가 없는 DDL, 테이블 레벨 FOREIGN KEY, `DECIMAL(10,2)`처럼 타입 안에 콤마가 있는 컬럼, `REFERENCES users(id) COMMENT 'links to user'`처럼 실제 참조와 주석이 함께 붙은 컬럼은 기존과 같게 처리됩니다.

## 알려진 한계

COMMENT 본문에 백슬래시 이스케이프(`\'`)가 들어 있으면 문자열 제거가 중간에 끝나서 오탐이 남습니다. 큰따옴표 COMMENT도 인식하지 않습니다. 두 항목은 이미 머지된 `ddlParser.ts`의 PK 판정이 가진 한계와 같습니다. 한쪽만 넓히면 두 파서의 규칙이 갈라지므로 이 PR은 `ddlParser`와 규칙을 맞추는 범위까지만 두었습니다. 이스케이프와 큰따옴표 처리는 두 파서를 함께 손보는 별도 PR로 올리겠습니다.

## 함께 올리는 PR

컬럼 정의 분리를 문자열 리터럴 인식 방식으로 바꾸는 PR(#34)을 같이 올립니다. COMMENT 본문에 콤마가 있으면 컬럼 정의를 나누는 단계에서 문자열이 쪼개집니다. 그러면 이 PR의 COMMENT 제외가 무효가 되는데 그 지점은 해당 PR이 맡습니다.

두 변경은 서로 독립적이고 머지 순서 의존성도 없습니다. `src/shared/erdParser.ts`는 자동 병합됩니다. `CHANGELOG.md`와 `webview-ui/src/utils/__tests__/erdParser.spec.ts`는 두 PR이 같은 자리에 항목을 추가하므로 나중에 머지되는 쪽에서 양쪽 항목이 모두 남도록 정리하겠습니다.

