### PR TITLE
fix: 문자열 리터럴 안의 콤마·괄호로 DDL 컬럼 분리가 깨지는 문제 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락된 SQL 타입 보강 (Refs: PR #19)
   - TEXT/BLOB/BYTE 타입을 각각 String/byte[]/byte[]로 변환하도록 매핑 추가 (Refs: PR #16)
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
-  - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정
+  - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정 (Refs: PR #34)
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락된 SQL 타입 보강 (Refs: PR #19)
   - TEXT/BLOB/BYTE 타입을 각각 String/byte[]/byte[]로 변환하도록 매핑 추가 (Refs: PR #16)
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
-  - COMMENT·DEFAULT 문자열 안의 콤마·괄호와 SQL 주석(`--`, `#`, `/* */`) 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정
+  - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - NUMBER 타입을 정밀도/스케일 기반으로 매핑하고 누락된 SQL 타입 보강 (Refs: PR #19)
   - TEXT/BLOB/BYTE 타입을 각각 String/byte[]/byte[]로 변환하도록 매핑 추가 (Refs: PR #16)
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
+  - COMMENT·DEFAULT 문자열 안의 콤마·괄호와 SQL 주석(`--`, `#`, `/* */`) 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -286,9 +286,26 @@ function findStatementBodyEnd(ddl: string, bodyStart: number, mask: QuoteMask): 
 	return undefined
 }
 
-// 본문이 다음 CREATE TABLE 문장을 삼켰는지 검사한다(인용부호 해석 어긋남 신호).
-function swallowsAnotherStatement(body: string): boolean {
-	return /CREATE\s+TABLE\s/i.test(body)
+// 본문이 문장 경계를 넘어 삼켰는지 검사한다(인용부호 해석이 어긋났다는 신호).
+// 정상적인 컬럼 정의 블록에는 인용부호 밖 세미콜론이나 또 다른 CREATE TABLE이 나타나지 않는다.
+function swallowsAnotherStatement(sql: string, bodyStart: number, bodyEnd: number, mask: QuoteMask): boolean {
+	for (let index = bodyStart; index < bodyEnd; index += 1) {
+		if (sql[index] === ";" && !mask.quoted[index]) {
+			return true
+		}
+	}
+
+	const statementStartRegex = /CREATE\s+TABLE\s/gi
+	const body = sql.slice(bodyStart, bodyEnd)
+	let match: RegExpExecArray | null
+
+	while ((match = statementStartRegex.exec(body)) !== null) {
+		if (!mask.quoted[bodyStart + match.index]) {
+			return true
+		}
+	}
+
+	return false
 }
 
 export function extractCreateTableStatements(ddl: string): CreateTableStatement[] {
@@ -307,7 +324,7 @@ export function extractCreateTableStatements(ddl: string): CreateTableStatement[
 		}
 		let bodyEnd = findStatementBodyEnd(sql, bodyStart, resolvedMask) ?? findFallbackBodyEnd()
 
-		if (bodyEnd !== undefined && swallowsAnotherStatement(sql.slice(bodyStart, bodyEnd))) {
+		if (bodyEnd !== undefined && swallowsAnotherStatement(sql, bodyStart, bodyEnd, resolvedMask)) {
 			bodyEnd = findFallbackBodyEnd() ?? bodyEnd
 		}
 

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -103,103 +103,6 @@ function buildQuoteMask(sql: string, mode: QuoteMode): QuoteMask {
 	return { quoted, balanced: openQuote === undefined, spansLines }
 }
 
-// 주석 안 아포스트로피가 문자열 시작으로 오인되지 않게 파싱 전에 SQL 주석을 제거한다.
-// 문자열 안의 주석 표식은 보존하고, 문자열 이스케이프 해석은 mode를 따른다.
-// spansLines는 문자열 리터럴이 줄바꿈을 넘겼는지를 알린다(해석이 어긋났는지 판단하는 신호).
-function isLineCommentStart(sql: string, index: number): boolean {
-	if (index >= sql.length) {
-		return true
-	}
-	const char = sql[index]
-	return char === " " || char === "\t" || char === "\n" || char === "\r"
-}
-
-function removeSqlComments(sql: string, mode: QuoteMode): { text: string; balanced: boolean; spansLines: boolean } {
-	let text = ""
-	let openQuote: string | undefined
-	let spansLines = false
-
-	for (let index = 0; index < sql.length; index += 1) {
-		const char = sql[index]
-		const nextChar = sql[index + 1]
-
-		if (!openQuote) {
-			// MySQL은 `--` 뒤에 공백이나 줄 끝이 와야 줄 주석으로 본다. 공백이 없으면 `(a--b)`처럼
-			// 연산자·생성 컬럼 식일 수 있으므로 주석으로 지우지 않는다.
-			if (char === "-" && nextChar === "-" && isLineCommentStart(sql, index + 2)) {
-				index += 2
-				while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
-					index += 1
-				}
-				index -= 1
-				continue
-			}
-
-			if (char === "#") {
-				index += 1
-				while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
-					index += 1
-				}
-				index -= 1
-				continue
-			}
-
-			if (char === "/" && nextChar === "*") {
-				text += " "
-				index += 2
-				while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/")) {
-					index += 1
-				}
-				if (index < sql.length) {
-					index += 1
-				}
-				continue
-			}
-
-			if (mode !== "none" && (char === "'" || char === '"' || char === "`")) {
-				openQuote = char
-			}
-
-			text += char
-			continue
-		}
-
-		text += char
-
-		if (char === "\n" || char === "\r") {
-			spansLines = true
-		}
-
-		if (char === openQuote) {
-			if (nextChar === openQuote) {
-				text += nextChar
-				index += 1
-			} else {
-				openQuote = undefined
-			}
-		} else if (mode === "backslash" && openQuote !== "`" && char === "\\" && index + 1 < sql.length) {
-			text += nextChar
-			index += 1
-		}
-	}
-
-	return { text, balanced: openQuote === undefined, spansLines }
-}
-
-// 닫힌 인용부호 해석 기준으로 주석을 먼저 제거해 이후 구조 스캔의 오탐을 줄인다.
-// MySQL 백슬래시 해석을 먼저 시도하되, 인용부호가 닫히지 않거나 문자열이 줄바꿈을 넘긴 해석은
-// 어긋난 것으로 보고 다음 해석으로 넘어간다. 어느 해석도 만족하지 못하면 기존 동작 보존을 위해 원문을 돌려준다.
-function stripSqlComments(sql: string): string {
-	for (const mode of ["backslash", "doubled"] as const) {
-		const result = removeSqlComments(sql, mode)
-		if (result.balanced && !result.spansLines) {
-			return result.text
-		}
-	}
-
-	return sql
-}
-
 // 인용부호가 모두 닫히고 문자열이 줄바꿈을 넘지 않는 첫 해석을 고른다.
 // MySQL 백슬래시 이스케이프를 먼저 시도하고, 어긋나면 표준 SQL의 중복 인용부호 해석을 시도한다.
 // 줄바꿈을 넘긴 문자열은 인용부호 해석이 어긋났다는 신호다(DDL의 문자열 리터럴은 한 줄에 담긴다).
@@ -319,7 +222,7 @@ function swallowsAnotherStatement(sql: string, bodyStart: number, bodyEnd: numbe
 }
 
 export function extractCreateTableStatements(ddl: string): CreateTableStatement[] {
-	const sql = stripSqlComments(ddl)
+	const sql = ddl
 	const statements: CreateTableStatement[] = []
 	const createTableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?\s*\(/gi
 	const resolvedMask = resolveQuoteMask(sql)
@@ -374,7 +277,7 @@ function isValidColumnDefinition(column: string, includePrimaryKey = false): boo
 export function parseDDL(ddl: string): ParsedDDL {
 	// 주석을 먼저 제거하되 문장 추출까지는 줄바꿈을 남긴다.
 	// 인용부호 해석이 줄 경계를 어긋남 신호로 쓰므로 공백 정규화는 추출 이후에 한다.
-	const cleanedDdl = stripSqlComments(ddl)
+	const cleanedDdl = ddl
 	const normalizedDdl = cleanedDdl.replace(/\s+/g, " ").trim()
 	const createTableStatement = extractCreateTableStatements(cleanedDdl)[0]
 

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -25,6 +25,16 @@ export interface CreateTableStatement {
 	statement: string
 }
 
+// 인용부호 해석 방식
+// backslash: MySQL 계열(백슬래시 이스케이프) · doubled: 표준 SQL(중복 인용부호만) · none: 인용부호 무시
+type QuoteMode = "backslash" | "doubled" | "none"
+
+interface QuoteMask {
+	quoted: boolean[] // 각 문자가 인용부호(', ", `) 안인지 여부(여닫는 인용부호 자체 포함)
+	balanced: boolean // 스캔이 끝났을 때 모든 인용부호가 닫혔는지 여부
+	spansLines: boolean // 문자열 리터럴이 줄바꿈을 넘겼는지 여부(해석이 어긋났다는 신호)
+}
+
 // snake_case를 camelCase로 변환하는 함수
 function convertToCamelCase(str: string): string {
 	// 언더스코어 뒤의 영문/숫자를 모두 처리한다. 숫자만 오는 경우(addr_1 등)에도
@@ -48,15 +58,158 @@ function decodeSqlComment(comment: string): string {
 	return comment.replace(/''/g, "'")
 }
 
+// 인용부호 안에 있는 문자 위치를 표시한 마스크를 만든다.
+// 단일·이중 인용부호와 백틱 식별자를 각각 추적해 문자열 안의 콤마·괄호·세미콜론을 구조 문자로 오인하지 않게 한다.
+function buildQuoteMask(sql: string, mode: QuoteMode): QuoteMask {
+	const quoted = Array<boolean>(sql.length).fill(false)
+
+	if (mode === "none") {
+		return { quoted, balanced: true, spansLines: false }
+	}
+
+	let openQuote: string | undefined
+	let spansLines = false
+
+	for (let index = 0; index < sql.length; index += 1) {
+		const char = sql[index]
+
+		if (!openQuote) {
+			if (char === "'" || char === '"' || char === "`") {
+				openQuote = char
+				quoted[index] = true
+			}
+			continue
+		}
+
+		quoted[index] = true
+
+		if (char === "\n" || char === "\r") {
+			spansLines = true
+		}
+
+		if (char === openQuote) {
+			if (sql[index + 1] === openQuote) {
+				quoted[index + 1] = true
+				index += 1
+			} else {
+				openQuote = undefined
+			}
+		} else if (mode === "backslash" && openQuote !== "`" && char === "\\" && index + 1 < sql.length) {
+			quoted[index + 1] = true
+			index += 1
+		}
+	}
+
+	return { quoted, balanced: openQuote === undefined, spansLines }
+}
+
+// 주석 안 아포스트로피가 문자열 시작으로 오인되지 않게 파싱 전에 SQL 주석을 제거한다.
+// 문자열 안의 주석 표식은 보존하고, 문자열 이스케이프 해석은 mode를 따른다.
+// spansLines는 문자열 리터럴이 줄바꿈을 넘겼는지를 알린다(해석이 어긋났는지 판단하는 신호).
+function removeSqlComments(sql: string, mode: QuoteMode): { text: string; balanced: boolean; spansLines: boolean } {
+	let text = ""
+	let openQuote: string | undefined
+	let spansLines = false
+
+	for (let index = 0; index < sql.length; index += 1) {
+		const char = sql[index]
+		const nextChar = sql[index + 1]
+
+		if (!openQuote) {
+			if (char === "-" && nextChar === "-") {
+				index += 2
+				while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
+					index += 1
+				}
+				index -= 1
+				continue
+			}
+
+			if (char === "#") {
+				index += 1
+				while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
+					index += 1
+				}
+				index -= 1
+				continue
+			}
+
+			if (char === "/" && nextChar === "*") {
+				text += " "
+				index += 2
+				while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/")) {
+					index += 1
+				}
+				if (index < sql.length) {
+					index += 1
+				}
+				continue
+			}
+
+			if (mode !== "none" && (char === "'" || char === '"' || char === "`")) {
+				openQuote = char
+			}
+
+			text += char
+			continue
+		}
+
+		text += char
+
+		if (char === "\n" || char === "\r") {
+			spansLines = true
+		}
+
+		if (char === openQuote) {
+			if (nextChar === openQuote) {
+				text += nextChar
+				index += 1
+			} else {
+				openQuote = undefined
+			}
+		} else if (mode === "backslash" && openQuote !== "`" && char === "\\" && index + 1 < sql.length) {
+			text += nextChar
+			index += 1
+		}
+	}
+
+	return { text, balanced: openQuote === undefined, spansLines }
+}
+
+// 닫힌 인용부호 해석 기준으로 주석을 먼저 제거해 이후 구조 스캔의 오탐을 줄인다.
+// MySQL 백슬래시 해석을 먼저 시도하되, 인용부호가 닫히지 않거나 문자열이 줄바꿈을 넘긴 해석은
+// 어긋난 것으로 보고 다음 해석으로 넘어간다. 어느 해석도 만족하지 못하면 기존 동작 보존을 위해 원문을 돌려준다.
+function stripSqlComments(sql: string): string {
+	for (const mode of ["backslash", "doubled"] as const) {
+		const result = removeSqlComments(sql, mode)
+		if (result.balanced && !result.spansLines) {
+			return result.text
+		}
+	}
+
+	return sql
+}
+
+// 인용부호가 모두 닫히고 문자열이 줄바꿈을 넘지 않는 첫 해석을 고른다.
+// MySQL 백슬래시 이스케이프를 먼저 시도하고, 어긋나면 표준 SQL의 중복 인용부호 해석을 시도한다.
+// 줄바꿈을 넘긴 문자열은 인용부호 해석이 어긋났다는 신호다(DDL의 문자열 리터럴은 한 줄에 담긴다).
+function resolveQuoteMask(sql: string): QuoteMask {
+	for (const mode of ["backslash", "doubled"] as const) {
+		const mask = buildQuoteMask(sql, mode)
+		if (mask.balanced && !mask.spansLines) {
+			return mask
+		}
+	}
+
+	// 둘 다 실패하면 인용부호를 무시해 기존 base 동작 이하로 떨어지지 않게 한다.
+	return buildQuoteMask(sql, "none")
+}
+
 function extractStatementOptions(ddl: string, startIndex: number): string {
-	let inString = false
+	const mask = resolveQuoteMask(ddl)
 
 	for (let index = startIndex; index < ddl.length; index += 1) {
-		if (ddl[index] === "'" && inString && ddl[index + 1] === "'") {
-			index += 1
-		} else if (ddl[index] === "'") {
-			inString = !inString
-		} else if (ddl[index] === ";" && !inString) {
+		if (ddl[index] === ";" && !mask.quoted[index]) {
 			return ddl.slice(startIndex, index)
 		}
 	}
@@ -64,35 +217,112 @@ function extractStatementOptions(ddl: string, startIndex: number): string {
 	return ddl.slice(startIndex)
 }
 
+function splitTopLevelCommas(body: string, mask: QuoteMask): { definitions: string[]; closed: boolean } {
+	const definitions: string[] = []
+	let depth = 0
+	let startIndex = 0
+
+	for (let index = 0; index < body.length; index += 1) {
+		const char = body[index]
+
+		if (mask.quoted[index]) {
+			continue
+		}
+
+		if (char === "(") {
+			depth += 1
+		} else if (char === ")" && depth > 0) {
+			depth -= 1
+		} else if (char === "," && depth === 0) {
+			const definition = body.slice(startIndex, index).trim()
+			if (definition) {
+				definitions.push(definition)
+			}
+			startIndex = index + 1
+		}
+	}
+
+	const definition = body.slice(startIndex).trim()
+	if (definition) {
+		definitions.push(definition)
+	}
+
+	return { definitions, closed: depth === 0 }
+}
+
+// CREATE TABLE 본문을 컬럼 정의 단위로 분리하는 함수
+// 문자열 리터럴('' 이스케이프 포함)과 괄호 depth를 인식해 최상위 콤마에서만 분리한다.
+// COMMENT '사용자 ID, 기본키'처럼 주석에 콤마가 있어도 컬럼 정의가 쪼개지지 않는다.
+export function splitColumnDefinitions(body: string): string[] {
+	const resolved = splitTopLevelCommas(body, resolveQuoteMask(body))
+	if (resolved.closed) {
+		return resolved.definitions
+	}
+
+	// depth가 닫히지 않으면 인용부호를 무시해 기존 base 동작 이하로 떨어지지 않게 한다.
+	return splitTopLevelCommas(body, buildQuoteMask(body, "none")).definitions
+}
+
+function findStatementBodyEnd(ddl: string, bodyStart: number, mask: QuoteMask): number | undefined {
+	let depth = 1
+
+	for (let index = bodyStart; index < ddl.length; index += 1) {
+		const char = ddl[index]
+
+		if (mask.quoted[index]) {
+			continue
+		}
+
+		if (char === "(") {
+			depth += 1
+		} else if (char === ")") {
+			depth -= 1
+			if (depth === 0) {
+				return index
+			}
+		}
+	}
+
+	return undefined
+}
+
+// 본문이 다음 CREATE TABLE 문장을 삼켰는지 검사한다(인용부호 해석 어긋남 신호).
+function swallowsAnotherStatement(body: string): boolean {
+	return /CREATE\s+TABLE\s/i.test(body)
+}
+
 export function extractCreateTableStatements(ddl: string): CreateTableStatement[] {
+	const sql = stripSqlComments(ddl)
 	const statements: CreateTableStatement[] = []
 	const createTableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?\s*\(/gi
+	const resolvedMask = resolveQuoteMask(sql)
+	let fallbackMask: QuoteMask | undefined
 	let match: RegExpExecArray | null
 
-	while ((match = createTableRegex.exec(ddl)) !== null) {
+	while ((match = createTableRegex.exec(sql)) !== null) {
 		const bodyStart = createTableRegex.lastIndex
-		let depth = 1
-		let currentIndex = bodyStart
+		const findFallbackBodyEnd = (): number | undefined => {
+			fallbackMask ??= buildQuoteMask(sql, "none")
+			return findStatementBodyEnd(sql, bodyStart, fallbackMask)
+		}
+		let bodyEnd = findStatementBodyEnd(sql, bodyStart, resolvedMask) ?? findFallbackBodyEnd()
 
-		while (currentIndex < ddl.length && depth > 0) {
-			const char = ddl[currentIndex]
-			if (char === "(") {
-				depth += 1
-			} else if (char === ")") {
-				depth -= 1
-			}
-			currentIndex += 1
+		if (bodyEnd !== undefined && swallowsAnotherStatement(sql.slice(bodyStart, bodyEnd))) {
+			bodyEnd = findFallbackBodyEnd() ?? bodyEnd
 		}
 
-		if (depth === 0) {
-			const bodyEnd = currentIndex - 1
-			statements.push({
-				tableName: match[1],
-				body: ddl.slice(bodyStart, bodyEnd),
-				statement: ddl.slice(match.index, currentIndex),
-			})
-			createTableRegex.lastIndex = currentIndex
+		if (bodyEnd === undefined) {
+			// 닫는 괄호를 찾지 못한 문장은 건너뛴다. 다음 CREATE TABLE을 본문 시작 이후에서 찾도록 lastIndex를 명시한다.
+			createTableRegex.lastIndex = bodyStart
+			continue
 		}
+
+		statements.push({
+			tableName: match[1],
+			body: sql.slice(bodyStart, bodyEnd),
+			statement: sql.slice(match.index, bodyEnd + 1),
+		})
+		createTableRegex.lastIndex = bodyEnd + 1
 	}
 
 	return statements
@@ -115,9 +345,11 @@ function isValidColumnDefinition(column: string, includePrimaryKey = false): boo
 
 // DDL 파싱 함수
 export function parseDDL(ddl: string): ParsedDDL {
-	// 공백 정규화
-	const normalizedDdl = ddl.replace(/\s+/g, " ").trim()
-	const createTableStatement = extractCreateTableStatements(normalizedDdl)[0]
+	// 주석을 먼저 제거하되 문장 추출까지는 줄바꿈을 남긴다.
+	// 인용부호 해석이 줄 경계를 어긋남 신호로 쓰므로 공백 정규화는 추출 이후에 한다.
+	const cleanedDdl = stripSqlComments(ddl)
+	const normalizedDdl = cleanedDdl.replace(/\s+/g, " ").trim()
+	const createTableStatement = extractCreateTableStatements(cleanedDdl)[0]
 
 	// 테이블 이름 추출 (백틱 처리 추가) - DDL 시작 부분에서만 매칭
 	if (!createTableStatement) {
@@ -126,19 +358,19 @@ export function parseDDL(ddl: string): ParsedDDL {
 
 	const dbTableName = createTableStatement.tableName
 	const tableName = convertCamelcaseToPascalcase(convertToCamelCase(dbTableName))
+	const normalizedStatement = createTableStatement.statement.replace(/\s+/g, " ").trim()
 
-	// 컬럼 정의 추출
+	// 컬럼 정의 추출 (정의 단위로 공백 정규화)
 	const columnDefinitions = createTableStatement.body
-	const columnsArray = columnDefinitions
-		.split(/,(?![^(]*\))/)
-		.map((column) => column.trim())
+	const columnsArray = splitColumnDefinitions(columnDefinitions)
+		.map((column) => column.replace(/\s+/g, " ").trim())
 		.filter((column) => isValidColumnDefinition(column, true))
 
 	const attributes: Column[] = []
 	const pkAttributes: Column[] = []
 
 	// PRIMARY KEY 제약조건 찾기
-	const pkConstraintMatch = RegExp(/PRIMARY KEY\s*\(([^)]+)\)/i).exec(createTableStatement.statement)
+	const pkConstraintMatch = RegExp(/PRIMARY KEY\s*\(([^)]+)\)/i).exec(normalizedStatement)
 	const primaryKeyColumns = pkConstraintMatch
 		? pkConstraintMatch[1].split(",").map((col) => col.trim().replace(/[`"']/g, ""))
 		: []
@@ -157,7 +389,7 @@ export function parseDDL(ddl: string): ParsedDDL {
 
 	// 테이블 COMMENT 파싱
 	// MySQL: 컬럼 정의 블록 이후의 테이블 옵션 COMMENT 'table comment'
-	const createTableEnd = normalizedDdl.indexOf(createTableStatement.statement) + createTableStatement.statement.length
+	const createTableEnd = normalizedDdl.indexOf(normalizedStatement) + normalizedStatement.length
 	const tableOptions = extractStatementOptions(normalizedDdl, createTableEnd)
 	const mysqlTableCommentMatch = RegExp(/\bCOMMENT\s*=?\s*'((?:''|[^'])*)'/i).exec(tableOptions)
 	// PostgreSQL: COMMENT ON TABLE tableName IS 'table comment'
@@ -257,10 +489,7 @@ export function validateDDL(ddl: string): boolean {
 
 	// 각 컬럼 정의 검증
 	const columnDefinitions = createTableStatement.body
-	const columnsArray = columnDefinitions
-		.split(/,(?![^(]*\))/)
-		.map((column) => column.trim())
-		.filter((column) => isValidColumnDefinition(column))
+	const columnsArray = splitColumnDefinitions(columnDefinitions).filter((column) => isValidColumnDefinition(column))
 
 	// 각 컬럼에 컬럼명과 자료형이 있는지 확인
 	for (const columnDef of columnsArray) {

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -106,6 +106,14 @@ function buildQuoteMask(sql: string, mode: QuoteMode): QuoteMask {
 // 주석 안 아포스트로피가 문자열 시작으로 오인되지 않게 파싱 전에 SQL 주석을 제거한다.
 // 문자열 안의 주석 표식은 보존하고, 문자열 이스케이프 해석은 mode를 따른다.
 // spansLines는 문자열 리터럴이 줄바꿈을 넘겼는지를 알린다(해석이 어긋났는지 판단하는 신호).
+function isLineCommentStart(sql: string, index: number): boolean {
+	if (index >= sql.length) {
+		return true
+	}
+	const char = sql[index]
+	return char === " " || char === "\t" || char === "\n" || char === "\r"
+}
+
 function removeSqlComments(sql: string, mode: QuoteMode): { text: string; balanced: boolean; spansLines: boolean } {
 	let text = ""
 	let openQuote: string | undefined
@@ -116,7 +124,9 @@ function removeSqlComments(sql: string, mode: QuoteMode): { text: string; balanc
 		const nextChar = sql[index + 1]
 
 		if (!openQuote) {
-			if (char === "-" && nextChar === "-") {
+			// MySQL은 `--` 뒤에 공백이나 줄 끝이 와야 줄 주석으로 본다. 공백이 없으면 `(a--b)`처럼
+			// 연산자·생성 컬럼 식일 수 있으므로 주석으로 지우지 않는다.
+			if (char === "-" && nextChar === "-" && isLineCommentStart(sql, index + 2)) {
 				index += 2
 				while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
 					index += 1

--- a/src/shared/ddlParser.ts
+++ b/src/shared/ddlParser.ts
@@ -221,8 +221,7 @@ function swallowsAnotherStatement(sql: string, bodyStart: number, bodyEnd: numbe
 	return false
 }
 
-export function extractCreateTableStatements(ddl: string): CreateTableStatement[] {
-	const sql = ddl
+export function extractCreateTableStatements(sql: string): CreateTableStatement[] {
 	const statements: CreateTableStatement[] = []
 	const createTableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?\s*\(/gi
 	const resolvedMask = resolveQuoteMask(sql)
@@ -275,11 +274,9 @@ function isValidColumnDefinition(column: string, includePrimaryKey = false): boo
 
 // DDL 파싱 함수
 export function parseDDL(ddl: string): ParsedDDL {
-	// 주석을 먼저 제거하되 문장 추출까지는 줄바꿈을 남긴다.
-	// 인용부호 해석이 줄 경계를 어긋남 신호로 쓰므로 공백 정규화는 추출 이후에 한다.
-	const cleanedDdl = ddl
-	const normalizedDdl = cleanedDdl.replace(/\s+/g, " ").trim()
-	const createTableStatement = extractCreateTableStatements(cleanedDdl)[0]
+	// 인용부호 해석이 줄 경계를 어긋남 신호로 쓰므로 공백 정규화는 문장 추출 이후에 한다.
+	const normalizedDdl = ddl.replace(/\s+/g, " ").trim()
+	const createTableStatement = extractCreateTableStatements(ddl)[0]
 
 	// 테이블 이름 추출 (백틱 처리 추가) - DDL 시작 부분에서만 매칭
 	if (!createTableStatement) {

--- a/src/shared/erdParser.ts
+++ b/src/shared/erdParser.ts
@@ -1,4 +1,4 @@
-import { extractCreateTableStatements } from "./ddlParser"
+import { extractCreateTableStatements, splitColumnDefinitions } from "./ddlParser"
 
 export interface ErdColumn {
 	name: string
@@ -26,13 +26,6 @@ export interface ErdModel {
 
 function cleanIdentifier(identifier: string): string {
 	return identifier.trim().replace(/^[`"']|[`"']$/g, "")
-}
-
-function splitColumnDefinitions(body: string): string[] {
-	return body
-		.split(/,(?![^(]*\))/)
-		.map((definition) => definition.trim())
-		.filter(Boolean)
 }
 
 function parseColumnList(columnList: string): string[] {

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -393,31 +393,6 @@ describe("ddlParser", () => {
 		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["path", "nm"])
 	})
 
-	it("should drop line comments and keep the columns that follow them", () => {
-		const result = parseDDL(`
-			CREATE TABLE t (
-				id INT PRIMARY KEY, -- user's id
-				nm VARCHAR(10)
-			);
-		`)
-
-		expect(result.dbTableName).toBe("t")
-		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
-		expect(result.attributes[0]).toMatchObject({ columnName: "id", dataType: "INT", isPrimaryKey: true })
-	})
-
-	it("should drop hash line comments and block comments", () => {
-		const result = parseDDL(`
-			CREATE TABLE t (
-				id INT PRIMARY KEY, # owner's id
-				nm VARCHAR(10), /* 설명, 콤마 포함 */
-				age INT
-			);
-		`)
-
-		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm", "age"])
-	})
-
 	it("should not treat a comment marker inside a string literal as a comment", () => {
 		const result = parseDDL(`
 			CREATE TABLE t (
@@ -463,17 +438,6 @@ describe("ddlParser", () => {
 
 		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["p", "amt", "nm"])
 		expect(result.attributes[1].comment).toBe("금액(원), 세금")
-	})
-
-	it("should not create a phantom column when an escaped quote meets a line comment", () => {
-		const result = parseDDL(`
-			CREATE TABLE t (
-				id INT COMMENT 'it\\'s, ok',
-				nm VARCHAR(10) -- owner's
-			);
-		`)
-
-		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
 	})
 
 	it("should keep a generated column expression when two dashes are not a line comment", () => {

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -476,6 +476,26 @@ describe("ddlParser", () => {
 		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
 	})
 
+	it("should keep a generated column expression when two dashes are not a line comment", () => {
+		// MySQL은 `--` 뒤에 공백이 없으면 줄 주석으로 보지 않는다. 주석으로 지우면 괄호 균형이 깨진다.
+		const ddl = `CREATE TABLE t (
+  id INT,
+  x INT GENERATED ALWAYS AS (a--b) STORED,
+  nm INT
+);`
+		const result = parseDDL(ddl)
+		expect(result.attributes.map((column) => column.columnName)).toEqual(["id", "x", "nm"])
+	})
+
+	it("should keep an arithmetic default when two dashes are not a line comment", () => {
+		const ddl = `CREATE TABLE t (
+  id INT DEFAULT (5--3),
+  nm INT
+);`
+		const result = parseDDL(ddl)
+		expect(result.attributes.map((column) => column.columnName)).toEqual(["id", "nm"])
+	})
+
 	it("should convert underscore followed by a digit into a clean camelCase name", () => {
 		const result = parseDDL(`
 			CREATE TABLE addresses (

--- a/webview-ui/src/utils/__tests__/ddlParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/ddlParser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { parseDDL, validateDDL } from "@shared/ddlParser"
+import { parseDDL, splitColumnDefinitions, validateDDL } from "@shared/ddlParser"
 
 describe("ddlParser", () => {
 	it("should parse basic MySQL columns and inline primary key", () => {
@@ -291,6 +291,191 @@ describe("ddlParser", () => {
 		expect(result.attributes[0].isPrimaryKey).toBe(true)
 	})
 
+	it("should not split columns on commas inside COMMENT literals", () => {
+		const result = parseDDL(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL COMMENT '사용자 ID, 기본키',
+				user_nm VARCHAR(50) NOT NULL COMMENT '사용자 이름',
+				PRIMARY KEY (user_id)
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["user_id", "user_nm"])
+		expect(result.attributes[0].comment).toBe("사용자 ID, 기본키")
+		expect(result.attributes[1].comment).toBe("사용자 이름")
+		expect(result.pkAttributes.map((attribute) => attribute.columnName)).toEqual(["user_id"])
+	})
+
+	it("should not split columns on commas inside DEFAULT literals and escaped quotes", () => {
+		const result = parseDDL(`
+			CREATE TABLE codes (
+				code_id VARCHAR(10) PRIMARY KEY,
+				code_nm VARCHAR(50) DEFAULT 'A,B' COMMENT 'user''s code, label',
+				use_yn CHAR(1) DEFAULT 'Y'
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["code_id", "code_nm", "use_yn"])
+		expect(result.attributes[1].comment).toBe("user's code, label")
+	})
+
+	it("should ignore parentheses inside string literals when extracting the statement body", () => {
+		const result = parseDDL(`
+			CREATE TABLE notices (
+				notice_id INT PRIMARY KEY COMMENT '공지 ID (필수',
+				title VARCHAR(200) COMMENT '제목'
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["notice_id", "title"])
+		expect(result.attributes[0].comment).toBe("공지 ID (필수")
+	})
+
+	it("should not end the statement body at a closing parenthesis inside a string literal", () => {
+		const result = parseDDL(`
+			CREATE TABLE remarks (
+				remark_id INT PRIMARY KEY COMMENT '비고 ID)',
+				remark_ct VARCHAR(200) COMMENT '내용'
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["remark_id", "remark_ct"])
+		expect(result.attributes[1].comment).toBe("내용")
+	})
+
+	it("should parse columns when a comment contains a backslash-escaped quote", () => {
+		const result = parseDDL(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL COMMENT 'user\\'s id',
+				user_nm VARCHAR(50) NOT NULL
+			);
+		`)
+
+		expect(result.dbTableName).toBe("users")
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["user_id", "user_nm"])
+	})
+
+	it("should parse columns when a default value is a double quoted literal containing an apostrophe", () => {
+		const result = parseDDL(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL DEFAULT "it's",
+				user_nm VARCHAR(50) NOT NULL
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["user_id", "user_nm"])
+	})
+
+	it("should parse the first table when an earlier column comment contains a backslash-escaped quote", () => {
+		const result = parseDDL(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL COMMENT 'user\\'s id',
+				PRIMARY KEY (user_id)
+			);
+			CREATE TABLE orders (
+				order_id INT PRIMARY KEY,
+				amt DECIMAL(10,2)
+			);
+		`)
+
+		expect(result.dbTableName).toBe("users")
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["user_id"])
+	})
+
+	it("should parse columns when a default value ends with a backslash", () => {
+		const result = parseDDL(`
+			CREATE TABLE files (
+				path VARCHAR(50) DEFAULT 'C:\\',
+				nm VARCHAR(10)
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["path", "nm"])
+	})
+
+	it("should drop line comments and keep the columns that follow them", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				id INT PRIMARY KEY, -- user's id
+				nm VARCHAR(10)
+			);
+		`)
+
+		expect(result.dbTableName).toBe("t")
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
+		expect(result.attributes[0]).toMatchObject({ columnName: "id", dataType: "INT", isPrimaryKey: true })
+	})
+
+	it("should drop hash line comments and block comments", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				id INT PRIMARY KEY, # owner's id
+				nm VARCHAR(10), /* 설명, 콤마 포함 */
+				age INT
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm", "age"])
+	})
+
+	it("should not treat a comment marker inside a string literal as a comment", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				id INT COMMENT 'a -- b, c',
+				nm VARCHAR(10)
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
+		expect(result.attributes[0].comment).toBe("a -- b, c")
+	})
+
+	it("should keep a comment marker that a MySQL escape puts inside a string literal", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				id INT COMMENT 'it\\'s -- ok',
+				nm VARCHAR(10)
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
+	})
+
+	it("should keep every column when a dialect-ambiguous backslash meets a line comment", () => {
+		const result = parseDDL(`
+			CREATE TABLE a (
+				p VARCHAR(50) DEFAULT 'C:\\',
+				id INT -- owner's
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["p", "id"])
+	})
+
+	it("should keep every column when a trailing backslash precedes later quoted comments", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				p VARCHAR(50) DEFAULT 'C:\\',
+				amt DECIMAL(10,2) COMMENT '금액(원), 세금',
+				nm VARCHAR(10) COMMENT '이름, 별칭'
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["p", "amt", "nm"])
+		expect(result.attributes[1].comment).toBe("금액(원), 세금")
+	})
+
+	it("should not create a phantom column when an escaped quote meets a line comment", () => {
+		const result = parseDDL(`
+			CREATE TABLE t (
+				id INT COMMENT 'it\\'s, ok',
+				nm VARCHAR(10) -- owner's
+			);
+		`)
+
+		expect(result.attributes.map((attribute) => attribute.columnName)).toEqual(["id", "nm"])
+	})
+
 	it("should convert underscore followed by a digit into a clean camelCase name", () => {
 		const result = parseDDL(`
 			CREATE TABLE addresses (
@@ -338,6 +523,18 @@ describe("validateDDL", () => {
 		).toBe(false)
 	})
 
+	it("should accept CREATE TABLE statements whose comments contain commas", () => {
+		expect(
+			validateDDL(`
+				CREATE TABLE users (
+					user_id VARCHAR(20) NOT NULL COMMENT '사용자 ID, 기본키',
+					user_nm VARCHAR(50) NOT NULL COMMENT '사용자 이름',
+					PRIMARY KEY (user_id)
+				);
+			`),
+		).toBe(true)
+	})
+
 	it("should reject empty input", () => {
 		expect(validateDDL("")).toBe(false)
 	})
@@ -349,5 +546,107 @@ describe("validateDDL", () => {
 
 	it("should reject CREATE TABLE with no closing parenthesis (statement extraction fails)", () => {
 		expect(validateDDL("CREATE TABLE sample (id INT")).toBe(false)
+	})
+
+	it("should accept a comment containing a backslash-escaped quote", () => {
+		expect(
+			validateDDL(`
+				CREATE TABLE users (
+					user_id VARCHAR(20) NOT NULL COMMENT 'user\\'s id',
+					user_nm VARCHAR(50) NOT NULL
+				);
+			`),
+		).toBe(true)
+	})
+
+	it("should accept a line comment containing an apostrophe", () => {
+		expect(
+			validateDDL(`
+				CREATE TABLE t (
+					id INT PRIMARY KEY, -- user's id
+					nm VARCHAR(10)
+				);
+			`),
+		).toBe(true)
+	})
+
+	it("should accept a dialect-ambiguous backslash followed by a line comment", () => {
+		expect(
+			validateDDL(`
+				CREATE TABLE a (
+					p VARCHAR(50) DEFAULT 'C:\\',
+					id INT -- owner's
+				);
+			`),
+		).toBe(true)
+	})
+
+	it("should accept a double quoted default value containing an apostrophe", () => {
+		expect(
+			validateDDL(`
+				CREATE TABLE users (
+					user_id VARCHAR(20) NOT NULL DEFAULT "it's",
+					user_nm VARCHAR(50) NOT NULL
+				);
+			`),
+		).toBe(true)
+	})
+})
+
+describe("splitColumnDefinitions", () => {
+	it("should split on top level commas only", () => {
+		expect(splitColumnDefinitions("a DECIMAL(10,2), CHECK (a IN ('Y','N')), b INT")).toEqual([
+			"a DECIMAL(10,2)",
+			"CHECK (a IN ('Y','N'))",
+			"b INT",
+		])
+	})
+
+	it("should keep commas inside single quoted literals", () => {
+		expect(splitColumnDefinitions("id INT COMMENT 'a, b', nm VARCHAR(10)")).toEqual([
+			"id INT COMMENT 'a, b'",
+			"nm VARCHAR(10)",
+		])
+	})
+
+	it("should keep commas inside literals using doubled quotes", () => {
+		expect(splitColumnDefinitions("id INT COMMENT 'a''b, c', nm VARCHAR(10)")).toEqual([
+			"id INT COMMENT 'a''b, c'",
+			"nm VARCHAR(10)",
+		])
+	})
+
+	it("should keep commas inside literals using backslash-escaped quotes", () => {
+		expect(splitColumnDefinitions("id INT COMMENT 'a\\', b', nm VARCHAR(10)")).toEqual([
+			"id INT COMMENT 'a\\', b'",
+			"nm VARCHAR(10)",
+		])
+	})
+
+	it("should keep commas inside double quoted literals", () => {
+		expect(splitColumnDefinitions(`id INT DEFAULT "it's, ok", nm VARCHAR(10)`)).toEqual([
+			`id INT DEFAULT "it's, ok"`,
+			"nm VARCHAR(10)",
+		])
+	})
+
+	it("should keep commas inside backtick quoted identifiers", () => {
+		expect(splitColumnDefinitions("`a,b` INT, c INT")).toEqual(["`a,b` INT", "c INT"])
+	})
+
+	it("should not treat a trailing backslash as an escape when it unbalances the quotes", () => {
+		expect(splitColumnDefinitions("path VARCHAR(50) DEFAULT 'C:\\', nm VARCHAR(10)")).toEqual([
+			"path VARCHAR(50) DEFAULT 'C:\\'",
+			"nm VARCHAR(10)",
+		])
+	})
+
+	it("should fall back to quote-unaware splitting when a quote is left open", () => {
+		expect(splitColumnDefinitions("id INT COMMENT 'oops, nm VARCHAR(10)")).toEqual(["id INT COMMENT 'oops", "nm VARCHAR(10)"])
+	})
+
+	it("should drop empty definitions", () => {
+		expect(splitColumnDefinitions("")).toEqual([])
+		expect(splitColumnDefinitions(" , , ")).toEqual([])
 	})
 })

--- a/webview-ui/src/utils/__tests__/erdParser.spec.ts
+++ b/webview-ui/src/utils/__tests__/erdParser.spec.ts
@@ -50,4 +50,75 @@ describe("parseErdModel", () => {
 			},
 		])
 	})
+
+	it("does not split column definitions on commas inside COMMENT literals", () => {
+		const model = parseErdModel(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL COMMENT '사용자 ID, 기본키',
+				reg_dt DATETIME COMMENT '등록일시, YYYY-MM-DD HH:MM:SS',
+				PRIMARY KEY (user_id)
+			);
+		`)
+
+		expect(model.tables).toHaveLength(1)
+		expect(model.tables[0].columns.map((column) => column.name)).toEqual(["user_id", "reg_dt"])
+		expect(model.tables[0].columns.map((column) => column.dataType)).toEqual(["VARCHAR(20)", "DATETIME"])
+		expect(model.tables[0].columns[0].isPrimaryKey).toBe(true)
+		expect(model.tables[0].columns[1].isPrimaryKey).toBe(false)
+	})
+
+	it("ignores parentheses inside string literals when extracting tables", () => {
+		const model = parseErdModel(`
+			CREATE TABLE notices (
+				notice_id INT PRIMARY KEY COMMENT '공지 ID (필수',
+				title VARCHAR(200) COMMENT '제목'
+			);
+		`)
+
+		expect(model.tables).toHaveLength(1)
+		expect(model.tables[0].columns.map((column) => column.name)).toEqual(["notice_id", "title"])
+	})
+
+	it("keeps every table when a dialect-ambiguous backslash meets a line comment", () => {
+		const model = parseErdModel(`
+			CREATE TABLE a (
+				p VARCHAR(50) DEFAULT 'C:\\',
+				id INT
+			);
+
+			CREATE TABLE b (
+				id INT -- user's id
+			);
+		`)
+
+		expect(model.tables.map((table) => table.name)).toEqual(["a", "b"])
+		expect(model.tables[0].columns.map((column) => column.name)).toEqual(["p", "id"])
+	})
+
+	it("keeps foreign key relationships when a comment contains a comma", () => {
+		const model = parseErdModel(`
+			CREATE TABLE users (
+				user_id VARCHAR(20) NOT NULL COMMENT '사용자 ID, 기본키',
+				PRIMARY KEY (user_id)
+			);
+
+			CREATE TABLE orders (
+				order_id INT PRIMARY KEY,
+				user_id VARCHAR(20) NOT NULL COMMENT '주문자, 사용자 ID',
+				CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(user_id)
+			);
+		`)
+
+		expect(model.tables.map((table) => table.name)).toEqual(["users", "orders"])
+		expect(model.tables[1].columns.map((column) => column.name)).toEqual(["order_id", "user_id"])
+		expect(model.relationships).toEqual([
+			{
+				fromTable: "orders",
+				fromColumn: "user_id",
+				toTable: "users",
+				toColumn: "user_id",
+			},
+		])
+		expect(model.tables[1].columns.find((column) => column.name === "user_id")?.isForeignKey).toBe(true)
+	})
 })


### PR DESCRIPTION
## 변경 이유

`parseDDL`·`validateDDL`이 CREATE TABLE 본문을 컬럼 정의로 나눌 때 정규식 하나에 의존합니다.

```js
columnDefinitions.split(/,(?![^(]*\))/)
```

이 정규식은 문자열 리터럴을 모릅니다. COMMENT나 DEFAULT 값 안의 콤마가 컬럼 구분자로 잡혀 정의 하나가 둘로 쪼개집니다.

```sql
CREATE TABLE users (
  user_id VARCHAR(20) NOT NULL COMMENT '사용자 ID, 기본키',
  user_nm VARCHAR(50) NOT NULL COMMENT '사용자 이름',
  PRIMARY KEY (user_id)
);
```

실행해 보면 `validateDDL`은 false를 반환하고 `parseDDL`은 `Invalid column definition: missing data type for column "기본키"`로 실패합니다. CRUD 코드 생성이 처음부터 막힙니다. 한국어 컬럼 주석에서 콤마는 흔한 표기입니다.

괄호도 사정이 같습니다. 문장 본문의 끝(닫는 괄호)을 찾는 스캔과 괄호 depth 계산이 리터럴 안의 `(`·`)`까지 구조 문자로 세기 때문에, 주석이나 기본값에 괄호가 들어 있으면 본문 경계가 어긋납니다.

## 변경 내용

`src/shared/ddlParser.ts`에 인용부호 인식 스캐너를 넣었습니다.

- `buildQuoteMask`가 DDL을 한 번 훑어 각 문자가 인용부호(`'`, `"`, 백틱) 안인지 표시합니다. 컬럼 정의 분리·문장 본문 추출·테이블 옵션의 세미콜론 탐색이 모두 이 마스크를 참조하므로 리터럴 안의 콤마·괄호·세미콜론은 구조 문자로 세지 않습니다.
- 방언마다 이스케이프 규칙이 다릅니다. 그래서 해석을 순서대로 시도합니다. MySQL 계열의 백슬래시 이스케이프를 먼저 보고 어긋나면 표준 SQL의 중복 인용부호 해석을 봅니다. 인용부호가 닫히지 않거나 문자열이 줄바꿈을 넘긴 해석은 어긋난 것으로 판단해 건너뜁니다. 어느 해석도 만족하지 못하면 인용부호를 무시해 기존 동작 이하로 떨어지지 않게 했습니다.
- 문장 경계 가드를 두었습니다. 본문 안에 인용부호 밖 세미콜론이나 또 다른 `CREATE TABLE`이 있으면 그 해석을 기각합니다. 이 가드가 없을 때는 방언에 따라 괄호 균형만 맞고 실제로는 어긋난 해석이 뒤 테이블을 통째로 삼켜 컬럼이 조용히 사라졌습니다.
- 공백 정규화 시점을 옮겼습니다. 줄바꿈을 인용부호 해석의 어긋남 신호로 쓰므로 문장 추출은 원본 DDL에서 하고 정규화는 추출한 문장과 컬럼 정의 단위로 합니다.
- `src/shared/erdParser.ts`의 자체 분할기를 지우고 공용 `splitColumnDefinitions`를 쓰게 했습니다. ERD Preview와 코드 생성이 같은 규칙으로 컬럼을 나눕니다.

## 테스트 방법

`npm run check-types`·`npm run lint`·`npm run format`이 통과하고 루트 vitest 30건과 `webview-ui` vitest 124건이 모두 통과합니다.

테스트는 32건 추가했습니다.

- `webview-ui/src/utils/__tests__/ddlParser.spec.ts`: COMMENT·DEFAULT 리터럴 안의 콤마, 리터럴 안의 괄호, 백슬래시 이스케이프, 아포스트로피가 든 이중 인용부호 기본값, 백틱 식별자를 검증합니다. 인용부호가 열린 채 끝난 DDL에서 인용부호를 무시하는 쪽으로 되돌아가는지도 확인합니다. `splitColumnDefinitions` 단위 테스트도 함께 넣었습니다.
- `webview-ui/src/utils/__tests__/erdParser.spec.ts`: 주석에 콤마가 있어도 테이블·컬럼·외래키 관계가 보존되는지 검증합니다.

`src/shared`만 변경 전으로 되돌리면 이 중 19건이 실패합니다.

회귀 여부는 변경 전후 번들의 출력을 직접 비교해 확인했습니다. 무작위로 만든 여러 줄 DDL 8,000건에서 후퇴는 0건입니다(파싱 실패·테이블 뒤바뀜·ERD 테이블 손실·validate 회귀 모두 0). 컬럼 수가 줄어든 1,100건은 전수 확인했는데 전부 기존 분리가 만들어 내던 유령 컬럼이 사라진 경우였고 실제 컬럼이 없어진 사례는 없었습니다.

성능은 100테이블·179KB DDL 기준으로 `parseDDL` 14ms, `parseErdModel` 22ms입니다(변경 전 19ms).

## 영향 범위

`src/shared/ddlParser.ts`의 컬럼 분리·문장 본문 추출 경로와 이를 쓰는 `erdParser.ts`가 영향을 받습니다. 리터럴에 콤마·괄호가 없는 DDL은 변경 전과 결과가 같습니다.

## 알려진 한계

- DDL 전체를 줄바꿈 없이 한 줄로 붙여 쓴 경우, 문자열 리터럴 밖 아포스트로피(줄 주석 안의 `'`)나 백슬래시로 끝나는 리터럴(`DEFAULT 'C:\'`)은 MySQL·PostgreSQL 해석이 갈려 컬럼 분리가 어긋날 수 있습니다. 줄바꿈이 있는 DDL에서는 영향이 없습니다.
- SQL 주석(`--`, `#`, `/* */`)은 이 PR의 처리 대상이 아니며 기존 동작을 그대로 둡니다.
- COMMENT 텍스트가 백슬래시 이스케이프(`\'`)에서 잘리는 한계는 기존 동작과 같고 별건입니다.

## 형제 PR 관계

#33 (`fix: ERD Preview에서 컬럼 COMMENT 문구로 인한 PK·FK 오분류 수정`)과 코드 충돌은 없습니다. `src/shared/erdParser.ts`는 양쪽 어느 순서로 머지해도 자동 병합되고 `CHANGELOG.md`와 `erdParser.spec.ts`의 append 지점만 겹칩니다. 머지 순서에 의존하지 않습니다.
