### PR TITLE
fix: 생성된 매퍼의 LIKE 검색이 MySQL에서 조건 없이 전체 행을 반환하는 문제 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - 컬럼 COMMENT 본문에 "primary key" 문구가 있을 때 해당 컬럼이 PK로 오분류되어 생성 SQL의 WHERE 절이 잘못되던 문제 수정 (Refs: PR #27)
   - ERD Preview에서 컬럼 COMMENT 본문의 "primary key"·"references" 문구를 제약조건으로 오인해 PK/FK가 잘못 표시되던 문제 수정 (Refs: PR #33)
   - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정 (Refs: PR #34)
+  - 생성된 MyBatis Mapper의 LIKE 검색이 문자열 결합에 `||`를 사용해 MySQL 기본 설정(PIPES_AS_CONCAT 미적용)에서 검색 조건이 무시되고 검색어와 무관하게 전체 행이 반환되던 문제 수정 — 방언 중립인 `<bind>`로 교체 (Refs: PR #35)
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/src/utils/__tests__/sampleMapperTemplate.spec.ts
+++ b/src/utils/__tests__/sampleMapperTemplate.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest"
+import * as fs from "fs"
+import * as path from "path"
+import * as Handlebars from "handlebars"
+
+interface Attribute {
+	columnName: string
+	ccName: string
+	isPrimaryKey: boolean
+}
+
+interface TemplateContext {
+	tableName: string
+	dbTableName: string
+	attributes: Attribute[]
+	pkAttributes: Attribute[]
+	packageName: string
+	className: string
+	classNameFirstCharLower: string
+}
+
+interface Fixture {
+	name: string
+	context: TemplateContext
+	branches: {
+		0: string
+		1?: string
+	}
+}
+
+const bindSearchPattern = `<bind name="searchPattern" value="'%' + searchKeyword + '%'"/>`
+
+// Mirrors the subset of registerHandlebarsHelpers in codeGenerator.ts used by this template.
+function registerTemplateHelpers() {
+	Handlebars.registerHelper("eq", function (a: any, b: any) {
+		return a === b
+	})
+
+	Handlebars.registerHelper("concat", function (...args: any[]) {
+		return args.slice(0, -1).join("")
+	})
+
+	Handlebars.registerHelper("setVar", function (varName: any, varValue: any, options: any) {
+		options.data.root[varName] = varValue
+	})
+
+	Handlebars.registerHelper("unless", function (this: any, conditional: any, options: any) {
+		if (!conditional) {
+			return options.fn(this)
+		} else {
+			return options.inverse(this)
+		}
+	})
+}
+
+function createContext(attributes: Attribute[]): TemplateContext {
+	return {
+		tableName: "sample",
+		dbTableName: "SAMPLE",
+		attributes,
+		pkAttributes: attributes.filter((attribute) => attribute.isPrimaryKey),
+		packageName: "egovframework.example.sample",
+		className: "Sample",
+		classNameFirstCharLower: "sample",
+	}
+}
+
+function renderTemplate(context: TemplateContext): string {
+	registerTemplateHelpers()
+
+	const templatePath = path.resolve(__dirname, "../../../templates/code/sample-mapper-template.hbs")
+	const templateContent = fs.readFileSync(templatePath, "utf8")
+	const template = Handlebars.compile(templateContent)
+
+	return template(context)
+}
+
+function countOccurrences(value: string, search: string): number {
+	return value.split(search).length - 1
+}
+
+function getSelectStatement(sql: string, id: string): string {
+	const match = sql.match(new RegExp(`<select id="${id}"[\\s\\S]*?<\\/select>`))
+	expect(match).not.toBeNull()
+
+	return match?.[0] ?? ""
+}
+
+function getSearchConditionBlock(statement: string, searchCondition: 0 | 1): string {
+	const match = statement.match(new RegExp(`<when test="searchCondition == ${searchCondition}">([\\s\\S]*?)<\\/when>`))
+	expect(match).not.toBeNull()
+
+	return match?.[1] ?? ""
+}
+
+function expectSearchBranch(statement: string, searchCondition: 0 | 1, columnName?: string) {
+	const block = getSearchConditionBlock(statement, searchCondition)
+
+	if (columnName) {
+		expect(block).toMatch(new RegExp(`${columnName}\\s+LIKE\\s+#\\{searchPattern\\}`))
+		expect(countOccurrences(block, "LIKE")).toBe(1)
+	} else {
+		expect(block).not.toContain("LIKE")
+	}
+}
+
+const fixtures: Fixture[] = [
+	{
+		name: "single primary key with non-primary columns",
+		context: createContext([
+			{ columnName: "SAMPLE_ID", ccName: "sampleId", isPrimaryKey: true },
+			{ columnName: "SAMPLE_NAME", ccName: "sampleName", isPrimaryKey: false },
+			{ columnName: "SAMPLE_DESC", ccName: "sampleDesc", isPrimaryKey: false },
+		]),
+		branches: {
+			0: "SAMPLE_ID",
+			1: "SAMPLE_NAME",
+		},
+	},
+	{
+		name: "composite primary key",
+		context: createContext([
+			{ columnName: "SAMPLE_ID", ccName: "sampleId", isPrimaryKey: true },
+			{ columnName: "SAMPLE_SEQ", ccName: "sampleSeq", isPrimaryKey: true },
+			{ columnName: "SAMPLE_NAME", ccName: "sampleName", isPrimaryKey: false },
+		]),
+		branches: {
+			0: "SAMPLE_ID",
+			1: "SAMPLE_SEQ",
+		},
+	},
+	{
+		name: "no primary key with two columns",
+		context: createContext([
+			{ columnName: "SAMPLE_NAME", ccName: "sampleName", isPrimaryKey: false },
+			{ columnName: "SAMPLE_DESC", ccName: "sampleDesc", isPrimaryKey: false },
+		]),
+		branches: {
+			0: "SAMPLE_NAME",
+			1: "SAMPLE_DESC",
+		},
+	},
+	{
+		name: "no primary key with one column",
+		context: createContext([{ columnName: "SAMPLE_NAME", ccName: "sampleName", isPrimaryKey: false }]),
+		branches: {
+			0: "SAMPLE_NAME",
+		},
+	},
+]
+
+describe("sample mapper template", () => {
+	it.each(fixtures)(
+		"renders LIKE search for $name without || because MySQL treats it as logical OR",
+		({ context, branches }) => {
+			const rendered = renderTemplate(context)
+			const listStatement = getSelectStatement(rendered, "selectSampleList")
+			const countStatement = getSelectStatement(rendered, "selectSampleListTotCnt")
+
+			expect(rendered).not.toContain("||")
+			expect(countOccurrences(rendered, bindSearchPattern)).toBe(2)
+			expect(countOccurrences(listStatement, bindSearchPattern)).toBe(1)
+			expect(countOccurrences(countStatement, bindSearchPattern)).toBe(1)
+
+			expect([...rendered.matchAll(/LIKE\s+([^\s<]+)/g)].map((match) => match[1])).toEqual(
+				Array(countOccurrences(rendered, "LIKE")).fill("#{searchPattern}"),
+			)
+			expect(rendered).not.toMatch(/LIKE\s+'%'/)
+			expect(rendered).not.toContain("LIKE #{searchKeyword}")
+
+			expect(listStatement.indexOf(bindSearchPattern)).toBeLessThan(listStatement.indexOf("LIKE"))
+			expect(countStatement.indexOf(bindSearchPattern)).toBeLessThan(countStatement.indexOf("LIKE"))
+
+			for (const statement of [listStatement, countStatement]) {
+				expectSearchBranch(statement, 0, branches[0])
+				expectSearchBranch(statement, 1, branches[1])
+			}
+
+			expect(rendered).toContain("LIMIT #{recordCountPerPage} OFFSET #{firstIndex}")
+			expect(rendered).toContain("ORDER BY")
+			expect(rendered).toContain("SELECT COUNT(*) totcnt")
+			expect(rendered).toContain(`<if test="searchKeyword != null and searchKeyword != ''">`)
+		},
+	)
+})

--- a/src/utils/__tests__/sampleMapperTemplate.spec.ts
+++ b/src/utils/__tests__/sampleMapperTemplate.spec.ts
@@ -30,7 +30,8 @@ interface Fixture {
 
 const bindSearchPattern = `<bind name="searchPattern" value="'%' + searchKeyword + '%'"/>`
 
-// Mirrors the subset of registerHandlebarsHelpers in codeGenerator.ts used by this template.
+// Mirrors the subset of registerHandlebarsHelpers in codeGeneratorUtils.ts used by this template.
+// unless는 Handlebars 내장 헬퍼라 등록하지 않는다(프로덕션도 오버라이드하지 않음).
 function registerTemplateHelpers() {
 	Handlebars.registerHelper("eq", function (a: any, b: any) {
 		return a === b
@@ -42,14 +43,6 @@ function registerTemplateHelpers() {
 
 	Handlebars.registerHelper("setVar", function (varName: any, varValue: any, options: any) {
 		options.data.root[varName] = varValue
-	})
-
-	Handlebars.registerHelper("unless", function (this: any, conditional: any, options: any) {
-		if (!conditional) {
-			return options.fn(this)
-		} else {
-			return options.inverse(this)
-		}
 	})
 }
 

--- a/templates/code/sample-mapper-template.hbs
+++ b/templates/code/sample-mapper-template.hbs
@@ -108,12 +108,13 @@
 			FROM {{dbTableName}}
 			WHERE 1=1
 			<if test="searchKeyword != null and searchKeyword != ''">
+				<bind name="searchPattern" value="'%' + searchKeyword + '%'"/>
 		        <choose>
 		            <when test="searchCondition == 0">
 					{{#if pkAttributes.length}}
-						AND	{{pkAttributes.[0].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND	{{pkAttributes.[0].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 					{{else}}
-						AND	{{attributes.[0].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND	{{attributes.[0].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 					{{/if}}
 					</when>
 		            <when test="searchCondition == 1">
@@ -122,16 +123,16 @@
 						{{#if (eq pkAttributes.length 1)}}
 							{{#each attributes}}
 								{{#unless isPrimaryKey~}}{{#unless @root.foundFirst~}}
-						AND {{columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 									{{~setVar "foundFirst" true~}}
 								{{/unless}}{{/unless}}
 							{{/each}}
 						{{else}}
-						AND	{{pkAttributes.[1].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND	{{pkAttributes.[1].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 						{{/if}}
 					{{else}}
 						{{#unless (eq attributes.length 1)}}
-						AND	{{attributes.[1].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND	{{attributes.[1].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 						{{/unless}}
 					{{/if}}
 					</when>
@@ -148,12 +149,13 @@
 			FROM {{dbTableName}}
 			WHERE 1=1
 			<if test="searchKeyword != null and searchKeyword != ''">
+				<bind name="searchPattern" value="'%' + searchKeyword + '%'"/>
 		        <choose>
 		            <when test="searchCondition == 0">
 					{{#if pkAttributes.length}}
-						AND {{pkAttributes.[0].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{pkAttributes.[0].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 					{{else}}
-						AND {{attributes.[0].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{attributes.[0].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 					{{/if}}
 					</when>
 		            <when test="searchCondition == 1">
@@ -162,16 +164,16 @@
 							{{~setVar "foundFirst" false~}}
 							{{#each attributes}}
 								{{#unless isPrimaryKey}}{{#unless @root.foundFirst}}
-						AND {{columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 									{{~setVar "foundFirst" true~}}
 								{{/unless}}{{/unless}}
 							{{/each}}
 						{{else}}
-						AND {{pkAttributes.[1].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{pkAttributes.[1].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 						{{/if}}
 					{{else}}
 						{{#unless (eq attributes.length 1)}}
-						AND {{attributes.[1].columnName}} LIKE '%' || {{concat "#{" "searchKeyword" "}"}} || '%'
+						AND {{attributes.[1].columnName}} LIKE {{concat "#{" "searchPattern" "}"}}
 						{{/unless}}
 					{{/if}}
 					</when>


### PR DESCRIPTION
## 변경 이유

`templates/code/sample-mapper-template.hbs`가 생성하는 목록 조회·건수 조회의 LIKE 검색은 검색어 패턴을 `||`로 조립합니다.

```xml
AND COLUMN LIKE '%' || #{searchKeyword} || '%'
```

`||`는 MySQL 기본 sql_mode(PIPES_AS_CONCAT 미적용)에서 문자열 결합이 아니라 논리 OR입니다. 게다가 `||`는 LIKE·AND보다 우선순위가 낮아서 위 조건절은 이렇게 파싱됩니다.

```
(1=1 AND COLUMN LIKE '%') OR #{searchKeyword} OR '%'
```

`COLUMN LIKE '%'`가 참이므로 WHERE 절 전체가 항상 참이 됩니다. 증상은 검색 실패가 아닙니다. 검색 조건이 통째로 무시되고 검색어와 무관하게 전체 행이 반환됩니다. 오류 없이 필터만 조용히 풀리는 형태라 오작동을 알아채기 어렵습니다. 이 확장이 코드 뷰에서 기본으로 선택하는 방언도 MySQL입니다(`webview-ui/src/components/egov/tabs/CodeView.tsx:80`, 샘플 DDL도 mysql 5건·pgsql 5건).

실제 DB에 붙여 확인했습니다. 3행짜리 테이블에 MySQL 8.0(기본 sql_mode)으로 질의하면, 수정 전에는 1행만 맞아야 할 `alpha` 검색에 3행 전부가 나오고 아무것도 맞지 않는 `zzzz` 검색에도 3행 전부가 나옵니다. 서버는 이때 `Warning 1287 '|| as a synonym for OR' is deprecated`를 함께 반환합니다. 수정 후 `alpha` 검색은 1행을 반환합니다. PostgreSQL 16에서는 `||`가 원래 결합 연산자라 수정 전후 모두 1행으로 결과가 같습니다. 회귀가 없습니다.

## 변경 내용

- 목록 조회(`selectXxxList`)와 건수 조회(`selectXxxListTotCnt`)의 `searchCondition` 0/1 분기 10곳 전부를 MyBatis `<bind>` 방식으로 교체했습니다.

  ```xml
  <if test="searchKeyword != null and searchKeyword != ''">
      <bind name="searchPattern" value="'%' + searchKeyword + '%'"/>
      ...
      AND COLUMN LIKE #{searchPattern}
  ```

  `<bind>`는 OGNL로 패턴 문자열을 만들어 파라미터로 넘기므로 특정 DB의 결합 연산자나 함수에 기대지 않습니다. MyBatis 공식 Dynamic SQL 문서의 `bind` 예시와 같은 형태입니다.
- `<bind>`는 `<if>` 안에 뒀습니다. `searchKeyword`가 null이면 `<if>`가 거짓이라 `<bind>`도 평가되지 않고 `WHERE 1=1`만 남습니다. statement마다 하나씩만 선언하므로 이름이 겹치지도 않습니다.
- 이번 변경은 LIKE 패턴 결합으로 한정합니다. 같은 템플릿의 `LIMIT ... OFFSET ...`은 이 확장이 노출하는 방언인 MySQL·PostgreSQL 양쪽 모두 지원하는 문법이라 손대지 않았습니다.

## 테스트 방법

MyBatis 동작은 3.5.19로 매퍼 XML을 실제로 파싱해 확인했습니다. `<bind>`는 `<if>`의 자식으로 DTD에 적법합니다. `searchCondition` 0/1·Map 파라미터·VO 파라미터 어느 경우에도 `AND COL LIKE ?` + `searchPattern => %ab'c%`로 바인딩됩니다. 작은따옴표가 섞인 검색어도 리터럴로 새지 않고 바인드 파라미터에 남습니다.

렌더 결과는 PK 1개·2개·3개, PK 없음, 컬럼 수 변화까지 픽스처 6종으로 수정 전후를 비교했습니다. 차이는 statement당 `<bind>` 한 줄 추가와 LIKE 줄 치환뿐입니다. `||` 렌더 건수는 수정 전 픽스처별 2~4건에서 수정 후 전 픽스처 0건이 됐습니다. 나머지 SQL 구조는 동일합니다.

회귀 테스트로 `src/utils/__tests__/sampleMapperTemplate.spec.ts` 4건을 추가했습니다. 단일 PK, 복합 PK, PK 없는 2컬럼, PK 없는 1컬럼 테이블을 렌더해 렌더 결과에 `||`가 남지 않는지, LIKE 우변이 전부 `#{searchPattern}`인지, `<bind>`가 statement당 1회이고 LIKE보다 앞에 오는지, 페이징·정렬·`<if>` 조건 등 나머지 구조가 유지되는지 검증합니다. 템플릿만 수정 전으로 되돌리면 이 4건이 모두 실패합니다.

검증 명령과 결과는 다음과 같습니다.

```
npm run check-types            # 통과
npm run lint                   # 통과
npm run format                 # 통과
npm test                       # 루트 34건 통과 (기존 30 + 신규 4)
cd webview-ui && npm test      # 92건 통과
```

## 영향 범위

- 생성물 중 매퍼 XML의 LIKE 검색 절만 바뀝니다. INSERT·UPDATE·DELETE, 정렬, 페이징, 컬럼 매핑은 그대로입니다.
- 파라미터는 여전히 `#{}`로 바인딩되므로 SQL 인젝션 표면에 변화가 없습니다. 오히려 SQL 문자열에 리터럴 `'%'`를 조립하던 부분이 사라집니다.
- 이미 생성해둔 매퍼 파일을 소급 수정하지는 않습니다. 이후 생성분부터 적용됩니다.
- `CHANGELOG.md`의 `## Unreleased` Code Generation 항목에 한 줄을 추가했습니다.
