### PR TITLE
fix: 웹뷰 메시지에 탭 스코프를 부여해 탭 간 오류 표시·출력 경로 교차 반응 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - ERD Preview에서 컬럼 COMMENT 본문의 "primary key"·"references" 문구를 제약조건으로 오인해 PK/FK가 잘못 표시되던 문제 수정 (Refs: PR #33)
   - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정 (Refs: PR #34)
   - 생성된 MyBatis Mapper의 LIKE 검색이 문자열 결합에 `||`를 사용해 MySQL 기본 설정(PIPES_AS_CONCAT 미적용)에서 검색 조건이 무시되고 검색어와 무관하게 전체 행이 반환되던 문제 수정 — 방언 중립인 `<bind>`로 교체 (Refs: PR #35)
+  - 코드 생성 실패 사유가 "알 수 없는 오류"로 대체되던 문제 수정 — 익스텐션 → 웹뷰 응답에 탭 스코프를 부여하고 실패 사유 페이로드를 text로 통일. 다른 탭의 실패가 Config 탭 오류 화면이나 Output Path 덮어쓰기로 번지지 않고, 프로젝트 템플릿 로드 실패는 Projects 탭에 표시된다 (Refs: PR #36)
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -98,6 +98,7 @@ export class Controller {
 						await this.postMessageToWebview({
 							type: "selectedOutputPath",
 							text: folders[0].fsPath,
+							scope: message.scope,
 						})
 					} else {
 						console.log("No folder selected")
@@ -174,6 +175,7 @@ export class Controller {
 					await this.postMessageToWebview({
 						type: "currentWorkspacePath",
 						text: workspaceFolders[0].uri.fsPath,
+						scope: message.scope,
 					})
 				}
 				break
@@ -210,18 +212,21 @@ export class Controller {
 						await this.postMessageToWebview({
 							type: "success",
 							text: "CRUD code generation completed successfully",
+							scope: "code",
 						})
 					} catch (error) {
 						console.error("CRUD code generation error:", error)
 						await this.postMessageToWebview({
 							type: "error",
 							text: error instanceof Error ? error.message : "Code generation failed",
+							scope: "code",
 						})
 					}
 				} else {
 					await this.postMessageToWebview({
 						type: "error",
 						text: "No DDL provided for code generation",
+						scope: "code",
 					})
 				}
 				break
@@ -235,11 +240,13 @@ export class Controller {
 						await this.postMessageToWebview({
 							type: "success",
 							text: "Custom template code generation completed successfully",
+							scope: "code",
 						})
 					} catch (error) {
 						await this.postMessageToWebview({
 							type: "error",
 							text: error instanceof Error ? error.message : "Template generation failed",
+							scope: "code",
 						})
 					}
 				}
@@ -254,11 +261,13 @@ export class Controller {
 						await this.postMessageToWebview({
 							type: "success",
 							text: "Template context downloaded successfully",
+							scope: "code",
 						})
 					} catch (error) {
 						await this.postMessageToWebview({
 							type: "error",
 							text: error instanceof Error ? error.message : "Template context download failed",
+							scope: "code",
 						})
 					}
 				}
@@ -351,12 +360,14 @@ export class Controller {
 						await this.postMessageToWebview({
 							type: "success",
 							text: "Configuration file generated successfully",
+							scope: "config",
 						})
 					} catch (error) {
 						console.error("Config generation error:", error)
 						await this.postMessageToWebview({
 							type: "error",
 							text: error instanceof Error ? error.message : "Configuration file generation failed",
+							scope: "config",
 						})
 					}
 				} else {
@@ -364,6 +375,7 @@ export class Controller {
 					await this.postMessageToWebview({
 						type: "error",
 						text: "Missing template or form data for config generation",
+						scope: "config",
 					})
 				}
 				break
@@ -524,7 +536,8 @@ export class Controller {
 					console.error("Error getting eGov settings:", error)
 					await this.postMessageToWebview({
 						type: "error",
-						message: "Failed to get eGov settings",
+						text: "Failed to get eGov settings",
+						scope: message.scope,
 					})
 				}
 				break
@@ -557,13 +570,15 @@ export class Controller {
 
 					await this.postMessageToWebview({
 						type: "success",
-						message: "Settings saved successfully",
+						text: "Settings saved successfully",
+						scope: "settings",
 					})
 				} catch (error) {
 					console.error("Error updating eGov settings:", error)
 					await this.postMessageToWebview({
 						type: "error",
-						message: "Failed to save settings",
+						text: "Failed to save settings",
+						scope: "settings",
 					})
 				}
 				break
@@ -594,7 +609,8 @@ export class Controller {
 					console.error("Error getting extension info:", error)
 					await this.postMessageToWebview({
 						type: "error",
-						message: "Failed to get extension info",
+						text: "Failed to get extension info",
+						scope: "settings",
 					})
 				}
 				break
@@ -619,7 +635,8 @@ export class Controller {
 					console.error("Error reading project templates:", error)
 					await this.postMessageToWebview({
 						type: "error",
-						message: "Failed to load project templates",
+						text: "Failed to load project templates",
+						scope: "projects",
 					})
 				}
 				break
@@ -644,7 +661,8 @@ export class Controller {
 					console.error("Error reading config templates:", error)
 					await this.postMessageToWebview({
 						type: "error",
-						message: "Failed to load config templates",
+						text: "Failed to load config templates",
+						scope: "config",
 					})
 				}
 				break

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,8 @@ export async function activate(context: vscode.ExtensionContext) {
 					action: "egovButtonClicked",
 				})
 
-				// Send current workspace path as default output path
+				// 특정 탭 요청에 대한 응답이 아니라 열려 있는 모든 탭에 기본 출력 경로를 알리는 브로드캐스트다.
+				// 그래서 currentWorkspacePath에는 scope를 붙이지 않는다.
 				const workspaceFolders = vscode.workspace.workspaceFolders
 				if (workspaceFolders && workspaceFolders.length > 0) {
 					const workspacePath = workspaceFolders[0].uri.fsPath

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -4,6 +4,8 @@
  * 익스텐션이 웹뷰로 보내는 메시지 타입
  */
 
+import type { WebviewScope } from "./WebviewMessage"
+
 export type ExtensionMessage =
 	| {
 			type: "action"
@@ -13,10 +15,12 @@ export type ExtensionMessage =
 	| {
 			type: "selectedOutputPath"
 			text: string
+			scope?: WebviewScope
 	  }
 	| {
 			type: "currentWorkspacePath"
 			text: string
+			scope?: WebviewScope
 	  }
 	| {
 			type: "projectGenerationProgress"
@@ -33,6 +37,7 @@ export type ExtensionMessage =
 			type: "success" | "error"
 			text?: string
 			message?: string
+			scope?: WebviewScope
 	  }
 	| {
 			type: "selectedOutputFolder"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -72,22 +72,28 @@ export interface EgovSettingsPayload {
 // 메시지 타입 (type 필드로 판별)
 // ---------------------------------------------------------------------------
 
+/** 웹뷰 탭별 메시지 발신 스코프 */
+export type WebviewScope = "projects" | "code" | "config" | "settings"
+
 /** 페이로드 없이 type만으로 동작하는 단순 요청 메시지 */
 export interface SimpleWebviewMessage {
 	type:
 		| "webviewDidLaunch"
-		| "selectOutputPath"
 		| "generateProjectByCommand"
-		| "getWorkspacePath"
 		| "getDefaultSettings"
 		| "openPackageSettings"
 		| "getSampleDDLs"
 		| "getCurrentTheme"
 		| "selectConfigFilePath"
-		| "getEgovSettings"
 		| "getExtensionInfo"
 		| "getProjectTemplates"
 		| "getConfigTemplates"
+}
+
+/** 탭 스코프를 선택적으로 포함하는 요청 메시지 */
+export interface ScopedRequestMessage {
+	type: "selectOutputPath" | "getWorkspacePath" | "getEgovSettings"
+	scope?: WebviewScope
 }
 
 export interface GenerateProjectMessage {
@@ -155,6 +161,7 @@ export interface UpdateEgovSettingsMessage {
 
 export type WebviewMessage =
 	| SimpleWebviewMessage
+	| ScopedRequestMessage
 	| GenerateProjectMessage
 	| GenerateCodeMessage
 	| UploadTemplatesMessage

--- a/src/shared/webviewMessageRouting.test.ts
+++ b/src/shared/webviewMessageRouting.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { getMessageText, isMessageForScope } from "./webviewMessageRouting"
+
+describe("webviewMessageRouting", () => {
+	describe("getMessageText", () => {
+		it("text 필드의 실패 사유를 보존한다", () => {
+			expect(getMessageText({ type: "error", text: "DDL 파싱 실패" })).toBe("DDL 파싱 실패")
+		})
+
+		it("message 필드만 있는 경우도 읽는다", () => {
+			expect(getMessageText({ type: "error", message: "기존 실패 사유" })).toBe("기존 실패 사유")
+		})
+
+		it("text와 message가 없거나 빈 문자열이면 undefined를 반환한다", () => {
+			expect(getMessageText({ type: "error" })).toBeUndefined()
+			expect(getMessageText({ type: "error", text: "", message: "   " })).toBeUndefined()
+		})
+	})
+
+	describe("isMessageForScope", () => {
+		it("code 스코프 error는 config 뷰에서 거부하고 code 뷰에서 허용한다", () => {
+			const message = { type: "error", scope: "code" as const, text: "Code failed" }
+
+			expect(isMessageForScope(message, "config")).toBe(false)
+			expect(isMessageForScope(message, "code")).toBe(true)
+		})
+
+		it("projects 스코프 selectedOutputPath는 code 뷰에서 거부한다", () => {
+			expect(isMessageForScope({ type: "selectedOutputPath", scope: "projects", text: "/tmp/out" }, "code")).toBe(false)
+		})
+
+		it("scope가 없는 메시지는 모든 뷰에서 허용한다", () => {
+			const message = { type: "selectedOutputPath", text: "/tmp/out" }
+
+			expect(isMessageForScope(message, "projects")).toBe(true)
+			expect(isMessageForScope(message, "code")).toBe(true)
+			expect(isMessageForScope(message, "config")).toBe(true)
+			expect(isMessageForScope(message, "settings")).toBe(true)
+		})
+	})
+})

--- a/src/shared/webviewMessageRouting.ts
+++ b/src/shared/webviewMessageRouting.ts
@@ -1,0 +1,40 @@
+/**
+ * webviewMessageRouting.ts
+ *
+ * 웹뷰가 익스텐션 메시지를 탭 스코프별로 라우팅하기 위한 순수 유틸리티.
+ *
+ * 이 파일은 웹뷰(webview-ui)에서도 import 하므로 런타임 의존성을 두지 않는다.
+ */
+
+import type { WebviewScope } from "./WebviewMessage"
+
+export type { WebviewScope }
+
+/** 라우팅 판단에 필요한 최소 형태 */
+export interface RoutableMessage {
+	type?: string
+	scope?: WebviewScope
+	text?: string
+	message?: string
+}
+
+export function getMessageText(message: RoutableMessage | null | undefined): string | undefined {
+	// 과거 발신부가 text/message를 섞어 보낸 이력이 있어 두 필드를 모두 읽는다.
+	if (typeof message?.text === "string" && message.text.trim() !== "") {
+		return message.text
+	}
+	if (typeof message?.message === "string" && message.message.trim() !== "") {
+		return message.message
+	}
+	return undefined
+}
+
+export function isMessageForScope(message: RoutableMessage | null | undefined, viewScope: WebviewScope): boolean {
+	if (!message) {
+		return false
+	}
+	if (message.scope === undefined) {
+		return true
+	}
+	return message.scope === viewScope
+}

--- a/src/shared/webviewMessageSchema.test.ts
+++ b/src/shared/webviewMessageSchema.test.ts
@@ -97,6 +97,17 @@ describe("parseWebviewMessage", () => {
 		}
 	})
 
+	it("scope를 선택적으로 받는 요청 메시지를 허용한다", () => {
+		expect(parseOk({ type: "selectOutputPath", scope: "code" })).toEqual({ type: "selectOutputPath", scope: "code" })
+		expect(parseOk({ type: "getWorkspacePath", scope: "projects" })).toEqual({
+			type: "getWorkspacePath",
+			scope: "projects",
+		})
+		expect(parseOk({ type: "getEgovSettings", scope: "settings" })).toEqual({ type: "getEgovSettings", scope: "settings" })
+		expect(parseOk({ type: "selectOutputPath" })).toEqual({ type: "selectOutputPath" })
+		parseFail({ type: "selectOutputPath", scope: "unknown" })
+	})
+
 	it("페이로드가 있는 모든 메시지의 정상 형태를 허용한다", () => {
 		parseOk({ type: "generateProject", projectConfig: validProjectConfig, method: "form" })
 		parseOk({ type: "generateCode", ddl: "CREATE TABLE t (id INT)", packageName: "com.example", outputPath: "/tmp/out" })

--- a/src/shared/webviewMessageSchema.ts
+++ b/src/shared/webviewMessageSchema.ts
@@ -94,20 +94,23 @@ const egovSettingsSchema = z.object({
 	language: z.string().optional(),
 })
 
+const webviewScopeSchema = z.enum(["projects", "code", "config", "settings"])
+
 /** 페이로드 없이 type만 전달하는 단순 요청 메시지 */
 const simpleMessage = <T extends string>(type: T) => z.object({ type: z.literal(type) })
+const scopedRequest = <T extends string>(type: T) => z.object({ type: z.literal(type), scope: webviewScopeSchema.optional() })
 
 export const webviewMessageSchema = z.discriminatedUnion("type", [
 	simpleMessage("webviewDidLaunch"),
-	simpleMessage("selectOutputPath"),
+	scopedRequest("selectOutputPath"),
 	simpleMessage("generateProjectByCommand"),
-	simpleMessage("getWorkspacePath"),
+	scopedRequest("getWorkspacePath"),
 	simpleMessage("getDefaultSettings"),
 	simpleMessage("openPackageSettings"),
 	simpleMessage("getSampleDDLs"),
 	simpleMessage("getCurrentTheme"),
 	simpleMessage("selectConfigFilePath"),
-	simpleMessage("getEgovSettings"),
+	scopedRequest("getEgovSettings"),
 	simpleMessage("getExtensionInfo"),
 	simpleMessage("getProjectTemplates"),
 	simpleMessage("getConfigTemplates"),

--- a/webview-ui/src/__mocks__/monaco-editor.ts
+++ b/webview-ui/src/__mocks__/monaco-editor.ts
@@ -1,0 +1,8 @@
+/**
+ * monaco-editor 스텁 (테스트 전용)
+ *
+ * monaco-editor 0.31은 package.json에 main 필드가 없어 Vitest 해석 단계에서 실패한다.
+ * 에디터 자체는 테스트 대상이 아니므로 vite.config.ts의 test.alias로 이 빈 모듈을 대신 쓴다.
+ */
+
+export {}

--- a/webview-ui/src/components/egov/EgovSettingsView.tsx
+++ b/webview-ui/src/components/egov/EgovSettingsView.tsx
@@ -1,5 +1,6 @@
 import { memo, useState, useEffect } from "react"
 import { Button, TextField, useVSCodeTheme, ResponsiveMenuButton, LanguageSelector } from "../ui"
+import { getMessageText, isMessageForScope } from "@shared/webviewMessageRouting"
 import { vscode } from "../../utils/vscode"
 import { validateEgovSettings } from "../../utils/settingsUtils"
 import i18n, { changeLanguage } from "../../i18n"
@@ -98,9 +99,12 @@ const EgovSettingsView = memo(({ onDone }: EgovSettingsViewProps) => {
 				}
 			}
 			if (message.type === "success") {
+				if (!isMessageForScope(message, "settings")) {
+					return
+				}
 				setSaveStatus({
 					isSaving: false,
-					message: message.message || t("common.settingsSaved"),
+					message: getMessageText(message) || t("common.settingsSaved"),
 					type: "success",
 				})
 				// 3초 후 메시지 숨기기
@@ -113,9 +117,12 @@ const EgovSettingsView = memo(({ onDone }: EgovSettingsViewProps) => {
 				}, 3000)
 			}
 			if (message.type === "error") {
+				if (!isMessageForScope(message, "settings")) {
+					return
+				}
 				setSaveStatus({
 					isSaving: false,
-					message: message.message || t("common.settingsSaveFailed"),
+					message: getMessageText(message) || t("common.settingsSaveFailed"),
 					type: "error",
 				})
 				// 5초 후 에러 메시지 숨기기
@@ -132,7 +139,7 @@ const EgovSettingsView = memo(({ onDone }: EgovSettingsViewProps) => {
 		window.addEventListener("message", handleMessage)
 
 		// 설정 및 확장 정보 요청
-		vscode.postMessage({ type: "getEgovSettings" })
+		vscode.postMessage({ type: "getEgovSettings", scope: "settings" })
 		vscode.postMessage({ type: "getExtensionInfo" })
 
 		return () => window.removeEventListener("message", handleMessage)

--- a/webview-ui/src/components/egov/tabs/CodeView.tsx
+++ b/webview-ui/src/components/egov/tabs/CodeView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { parseDDL, validateDDL, ParsedDDL } from "@shared/ddlParser"
 import { parseErdModel } from "@shared/erdParser"
 import { getTemplateContext } from "@shared/templateContext"
+import { getMessageText, isMessageForScope } from "@shared/webviewMessageRouting"
 import { ExtensionResponse } from "../../../utils/messageTypes"
 import { createSelectOutputPathMessage } from "../../../utils/egovUtils"
 import { vscode } from "../../../utils/vscode"
@@ -286,10 +287,10 @@ const CodeView = () => {
 
 		// Request current workspace path when component mounts
 		try {
-			vscode.postMessage({ type: "getWorkspacePath" })
+			vscode.postMessage({ type: "getWorkspacePath", scope: "code" })
 			vscode.postMessage({ type: "getSampleDDLs" })
 			vscode.postMessage({ type: "getCurrentTheme" })
-			vscode.postMessage({ type: "getEgovSettings" })
+			vscode.postMessage({ type: "getEgovSettings", scope: "code" })
 		} catch (err) {
 			console.error("Error sending message:", err)
 		}
@@ -297,18 +298,28 @@ const CodeView = () => {
 		const handleMessage = (event: MessageEvent) => {
 			const message = event.data
 			console.log("Received message from extension:", message)
-			setIsLoading(false)
 
 			if (message && typeof message === "object" && "type" in message) {
 				switch (message.type) {
-					case "error":
-						console.error("Extension error:", message.message)
-						setError(message.message || t("common.unknownError"))
+					case "error": {
+						if (!isMessageForScope(message, "code")) {
+							break
+						}
+						const errorMessage = getMessageText(message) || t("common.unknownError")
+						console.error("Extension error:", errorMessage)
+						setIsLoading(false)
+						setError(errorMessage)
 						break
-					case "success":
-						console.log("Extension success:", message.message)
+					}
+					case "success": {
+						if (!isMessageForScope(message, "code")) {
+							break
+						}
+						console.log("Extension success:", getMessageText(message))
+						setIsLoading(false)
 						setError("")
 						break
+					}
 					case "sampleDDLs":
 						const sampleList = message.data as Extract<ExtensionResponse, { type: "sampleDDLs" }>["data"]
 						setSampleDDLs(sampleList || {})
@@ -317,12 +328,18 @@ const CodeView = () => {
 						// setDdlContent(defaultSample?.ddl || "")
 						break
 					case "selectedOutputPath":
+						if (!isMessageForScope(message, "code")) {
+							break
+						}
 						if (message.text) {
 							setOutputPath(message.text)
 							setValidationErrors([]) // Clear validation errors
 						}
 						break
 					case "currentWorkspacePath":
+						if (!isMessageForScope(message, "code")) {
+							break
+						}
 						if (message.text) {
 							setOutputPath(message.text)
 						}
@@ -486,7 +503,7 @@ const CodeView = () => {
 				return
 			}
 
-			const message = createSelectOutputPathMessage()
+			const message = createSelectOutputPathMessage("code")
 			console.log("Sending message:", message)
 			vscode.postMessage(message)
 		} catch (err) {

--- a/webview-ui/src/components/egov/tabs/ConfigView.tsx
+++ b/webview-ui/src/components/egov/tabs/ConfigView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Button, TextField, TextArea, Select, RadioGroup, ProgressRing, Link, Divider } from "../../ui"
+import { getMessageText, isMessageForScope } from "@shared/webviewMessageRouting"
 import { TemplateConfig, GroupedTemplates, ConfigFormData } from "../types/templates"
 import { groupTemplates } from "../../../utils/templateUtils"
 import FormFactory from "../forms/FormFactory"
@@ -43,7 +44,10 @@ const ConfigView: React.FC = () => {
 					}
 					break
 				case "error":
-					setError(message.message || t("config.failedToLoadTemplates"))
+					if (!isMessageForScope(message, "config")) {
+						break
+					}
+					setError(getMessageText(message) || t("config.failedToLoadTemplates"))
 					updateState({ isTemplatesLoading: false })
 					break
 			}

--- a/webview-ui/src/components/egov/tabs/ProjectsView.tsx
+++ b/webview-ui/src/components/egov/tabs/ProjectsView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, TextField, TextArea, Select, RadioGroup, ProgressRing, Link, Divider } from "../../ui"
+import { getMessageText, isMessageForScope } from "@shared/webviewMessageRouting"
 import { vscode } from "../../../utils/vscode"
 import {
 	ProjectTemplate,
@@ -61,11 +62,12 @@ export const ProjectsView = () => {
 
 	// Sample 버튼(handleInsertSample)을 위해 초기 출력 경로 설정
 	const [initialPath, setInitialPath] = useState("")
+	const [templatesError, setTemplatesError] = useState("")
 
 	useEffect(() => {
 		// Request project templates, workspace path and default settings when component mounts
 		vscode.postMessage({ type: "getProjectTemplates" })
-		vscode.postMessage({ type: "getWorkspacePath" })
+		vscode.postMessage({ type: "getWorkspacePath", scope: "projects" })
 		vscode.postMessage({ type: "getDefaultSettings" })
 
 		// Listen for messages from extension
@@ -75,18 +77,32 @@ export const ProjectsView = () => {
 				case "projectTemplates":
 					// Update project templates from extension
 					if (message.templates) {
+						setTemplatesError("")
 						updateState({
 							projectTemplates: message.templates,
 							isTemplatesLoading: false,
 						})
 					}
 					break
+				case "error":
+					if (!isMessageForScope(message, "projects")) {
+						break
+					}
+					setTemplatesError(getMessageText(message) || t("projects.failedToLoadTemplates"))
+					updateState({ isTemplatesLoading: false })
+					break
 				case "selectedOutputPath":
+					if (!isMessageForScope(message, "projects")) {
+						break
+					}
 					if (message.text) {
 						setOutputPath(message.text)
 					}
 					break
 				case "currentWorkspacePath":
+					if (!isMessageForScope(message, "projects")) {
+						break
+					}
 					// Set workspace path as default output path
 					if (message.text) {
 						setOutputPath(message.text)
@@ -146,7 +162,7 @@ export const ProjectsView = () => {
 	}
 
 	const handleSelectOutputPath = () => {
-		vscode.postMessage(createSelectOutputPathMessage())
+		vscode.postMessage(createSelectOutputPathMessage("projects"))
 	}
 
 	const validateForm = (): boolean => {
@@ -429,7 +445,11 @@ export const ProjectsView = () => {
 								overflowY: "auto",
 								backgroundColor: "var(--vscode-input-background)",
 							}}>
-							{isTemplatesLoading ? (
+							{templatesError ? (
+								<div style={{ textAlign: "center", padding: "20px", color: "var(--vscode-errorForeground)" }}>
+									{templatesError}
+								</div>
+							) : isTemplatesLoading ? (
 								<div
 									style={{
 										textAlign: "center",

--- a/webview-ui/src/components/egov/tabs/__tests__/CodeView.spec.tsx
+++ b/webview-ui/src/components/egov/tabs/__tests__/CodeView.spec.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import "../../../../i18n"
+import { EgovTabsStateProvider } from "../../../../context/EgovTabsStateContext"
+
+// Monaco 에디터는 이 테스트의 관심사(메시지 라우팅)와 무관하고 jsdom에서 로드할 수 없어 최소 스텁으로 대체한다
+vi.mock("@monaco-editor/react", () => ({
+	default: () => <div data-testid="monaco-editor" />,
+	loader: { config: vi.fn() },
+}))
+vi.mock("monaco-sql-languages/esm/languages/mysql/mysql.contribution", () => ({}))
+vi.mock("monaco-sql-languages/esm/languages/pgsql/pgsql.contribution", () => ({}))
+vi.mock("monaco-sql-languages/esm/languages/mysql/mysql.worker?worker&inline", () => ({ default: class {} }))
+vi.mock("monaco-sql-languages/esm/languages/pgsql/pgsql.worker?worker&inline", () => ({ default: class {} }))
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker&inline", () => ({ default: class {} }))
+
+vi.mock("../../../../utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+const CodeView = (await import("../CodeView")).default
+
+const renderCodeView = () =>
+	render(
+		<EgovTabsStateProvider>
+			<CodeView />
+		</EgovTabsStateProvider>,
+	)
+
+const dispatch = (data: unknown) => {
+	act(() => {
+		window.dispatchEvent(new MessageEvent("message", { data }))
+	})
+}
+
+describe("CodeView 메시지 스코프", () => {
+	it("code 스코프 error는 사유를 그대로 표시한다", async () => {
+		renderCodeView()
+
+		dispatch({ type: "error", scope: "code", text: "DDL 파싱 실패: 3번째 컬럼" })
+
+		await waitFor(() => expect(screen.getByText("DDL 파싱 실패: 3번째 컬럼")).toBeInTheDocument())
+		expect(screen.queryByText("Unknown error occurred.")).not.toBeInTheDocument()
+	})
+
+	it("다른 탭의 error는 표시하지 않는다", async () => {
+		renderCodeView()
+
+		dispatch({ type: "error", scope: "config", text: "템플릿 JSON 파싱 실패" })
+
+		await waitFor(() => expect(screen.getByTestId("monaco-editor")).toBeInTheDocument())
+		expect(screen.queryByText("템플릿 JSON 파싱 실패")).not.toBeInTheDocument()
+		// 스코프 가드가 없으면 사유를 읽지 못한 채 "알 수 없는 오류" 배너가 뜬다
+		expect(screen.queryByText("Unknown error occurred.")).not.toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/egov/tabs/__tests__/ConfigView.spec.tsx
+++ b/webview-ui/src/components/egov/tabs/__tests__/ConfigView.spec.tsx
@@ -1,0 +1,67 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import "../../../../i18n"
+import { EgovTabsStateProvider } from "../../../../context/EgovTabsStateContext"
+import ConfigView from "../ConfigView"
+
+vi.mock("../../../../utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+const configTemplates = [
+	{
+		displayName: "Datasource > New Datasource",
+		templateFolder: "datasource",
+		templateFile: "datasource.hbs",
+		webView: "datasource-form.tsx",
+		fileNameProperty: "txtFileName",
+		javaConfigTemplate: "datasource-java.hbs",
+		yamlTemplate: "",
+		propertiesTemplate: "",
+	},
+]
+
+const renderConfigView = () =>
+	render(
+		<EgovTabsStateProvider>
+			<ConfigView />
+		</EgovTabsStateProvider>,
+	)
+
+describe("ConfigView 메시지 스코프", () => {
+	it("code 스코프 error는 템플릿 로드 오류 화면으로 전환하지 않는다", async () => {
+		renderConfigView()
+
+		act(() => {
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "configTemplates", templates: configTemplates } }))
+		})
+		await waitFor(() => expect(screen.getByText("Generate eGovFrame Configurations")).toBeInTheDocument())
+
+		act(() => {
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "error", scope: "code", text: "DDL 파싱 실패" } }))
+		})
+
+		expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument()
+		expect(screen.queryByText("DDL 파싱 실패")).not.toBeInTheDocument()
+	})
+
+	it("config 스코프 error는 실제 사유를 표시하는 오류 화면으로 전환한다", async () => {
+		renderConfigView()
+
+		act(() => {
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "configTemplates", templates: configTemplates } }))
+		})
+		await waitFor(() => expect(screen.getByText("Generate eGovFrame Configurations")).toBeInTheDocument())
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", { data: { type: "error", scope: "config", text: "템플릿 JSON 파싱 실패" } }),
+			)
+		})
+
+		await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument())
+		expect(screen.getByText("템플릿 JSON 파싱 실패")).toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/egov/tabs/__tests__/ProjectsView.spec.tsx
+++ b/webview-ui/src/components/egov/tabs/__tests__/ProjectsView.spec.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import "../../../../i18n"
+import { EgovTabsStateProvider } from "../../../../context/EgovTabsStateContext"
+import { ProjectsView } from "../ProjectsView"
+
+vi.mock("../../../../utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+const projectTemplates = [
+	{
+		displayName: "Sample Project",
+		fileName: "sample-project.zip",
+		pomFile: "",
+		description: "Sample project template",
+		category: "Sample",
+		projectName: "sample-project",
+	},
+]
+
+const renderProjectsView = () =>
+	render(
+		<EgovTabsStateProvider>
+			<ProjectsView />
+		</EgovTabsStateProvider>,
+	)
+
+describe("ProjectsView 메시지 스코프", () => {
+	it("다른 탭의 selectedOutputPath는 무시하고 projects 스코프만 Output Path에 반영한다", async () => {
+		renderProjectsView()
+
+		act(() => {
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "projectTemplates", templates: projectTemplates } }))
+		})
+
+		await waitFor(() => expect(screen.getByText("Sample Project")).toBeInTheDocument())
+		fireEvent.click(screen.getByText("Sample Project"))
+
+		const outputPathInput = await screen.findByLabelText(/Output Path/)
+		expect(outputPathInput).toHaveValue("")
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", { data: { type: "selectedOutputPath", scope: "code", text: "/code/out" } }),
+			)
+		})
+
+		expect(outputPathInput).toHaveValue("")
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", { data: { type: "selectedOutputPath", scope: "projects", text: "/projects/out" } }),
+			)
+		})
+
+		await waitFor(() => expect(outputPathInput).toHaveValue("/projects/out"))
+	})
+	it("projects 스코프 error는 템플릿 로딩을 끝내고 사유를 표시한다", async () => {
+		renderProjectsView()
+
+		expect(screen.getByText("Loading templates...")).toBeInTheDocument()
+
+		act(() => {
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "error", scope: "code", text: "DDL 파싱 실패" } }))
+		})
+
+		expect(screen.getByText("Loading templates...")).toBeInTheDocument()
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: { type: "error", scope: "projects", text: "Failed to load project templates" },
+				}),
+			)
+		})
+
+		await waitFor(() => expect(screen.getByText("Failed to load project templates")).toBeInTheDocument())
+		expect(screen.queryByText("Loading templates...")).not.toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/i18n/locales/en.json
+++ b/webview-ui/src/i18n/locales/en.json
@@ -51,6 +51,7 @@
 		"templateCategory": "Template Category",
 		"templateSelection": "Template Selection",
 		"loadingTemplates": "Loading templates...",
+		"failedToLoadTemplates": "Failed to load project templates. Please try again.",
 		"noTemplates": "No templates available",
 		"projectConfiguration": "Project Configuration",
 		"projectName": "Project Name",

--- a/webview-ui/src/i18n/locales/ko.json
+++ b/webview-ui/src/i18n/locales/ko.json
@@ -51,6 +51,7 @@
 		"templateCategory": "템플릿 카테고리",
 		"templateSelection": "템플릿 선택",
 		"loadingTemplates": "템플릿 로딩 중...",
+		"failedToLoadTemplates": "프로젝트 템플릿 로드에 실패했습니다. 다시 시도해 주세요.",
 		"noTemplates": "사용 가능한 템플릿이 없습니다",
 		"projectConfiguration": "프로젝트 설정",
 		"projectName": "프로젝트 이름",

--- a/webview-ui/src/utils/egovUtils.ts
+++ b/webview-ui/src/utils/egovUtils.ts
@@ -1,12 +1,16 @@
-export function createSelectOutputPathMessage() {
+import type { WebviewScope } from "@shared/WebviewMessage"
+
+export function createSelectOutputPathMessage(scope?: WebviewScope) {
 	return {
 		type: "selectOutputPath" as const,
+		...(scope ? { scope } : {}),
 	}
 }
 
-export function createGetWorkspacePathMessage() {
+export function createGetWorkspacePathMessage(scope?: WebviewScope) {
 	return {
 		type: "getWorkspacePath" as const,
+		...(scope ? { scope } : {}),
 	}
 }
 

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
 		environment: "jsdom",
 		globals: true,
 		setupFiles: ["./src/setupTests.ts"],
+		// monaco-editor 0.31은 package.json에 main 필드가 없어 테스트 환경에서 해석되지 않는다.
+		// 에디터는 테스트 대상이 아니므로 테스트에서만 빈 스텁으로 대체한다.
+		alias: [{ find: /^monaco-editor$/, replacement: resolve(__dirname, "./src/__mocks__/monaco-editor.ts") }],
 		coverage: {
 			provider: "v8",
 			reportOnFailure: true,


### PR DESCRIPTION
## 변경 이유

`EgovView`는 Code·Config·Projects 세 탭을 `display: none`으로 상시 마운트합니다. 세 탭이 같은 `window` 메시지를 동시에 받는데 익스텐션이 보내는 응답에는 어느 탭이 받아야 할 응답인지 구분할 정보가 없습니다. 여기서 세 가지 문제가 생깁니다.

### 1. 코드 생성 실패 사유가 "알 수 없는 오류가 발생했습니다"로 대체됩니다

익스텐션은 실패 사유를 `text`와 `message` 두 필드에 섞어 보냅니다.

```ts
// src/core/controller/index.ts — 코드·설정 생성 계열
await this.postMessageToWebview({ type: "error", text: error.message })
// 같은 파일 — 설정·템플릿 조회 계열
await this.postMessageToWebview({ type: "error", message: "Failed to load project templates" })
```

`CodeView`는 `message.message`만 읽으므로 `text`로 도착한 사유는 잡지 못하고 `t("common.unknownError")`로 대체합니다. 정작 사용자가 알아야 할 실제 실패 원인이 화면에 나오지 않습니다.

### 2. Code 탭에서 생성이 실패하면 Config 탭이 오류 화면으로 바뀝니다

`ConfigView`는 수신한 모든 `error`를 템플릿 로드 실패로 간주해 전면 오류 화면을 띄웁니다. 상시 마운트된 상태라 코드 생성 실패 메시지도 그대로 받습니다. 사용자가 Config 탭으로 넘어가면 설정 폼 대신 "템플릿 로드에 실패했습니다. 다시 시도해 주세요."가 떠 있습니다.

### 3. 한쪽 탭에서 폴더를 고르면 다른 탭의 출력 경로가 덮어써집니다

`selectedOutputPath`·`currentWorkspacePath`를 Projects 탭과 Code 탭이 함께 받습니다. Projects 탭에서 출력 폴더를 선택하면 Code 탭의 Output Path도 조용히 같은 값으로 바뀝니다.

## 변경 내용

- `ExtensionMessage`·`WebviewMessage`와 zod 스키마에 선택 필드 `scope`(`"code" | "config" | "projects" | "settings"`)를 추가했습니다.
- 각 뷰는 `isMessageForScope(message, <자기 스코프>)`로 자기 몫만 처리합니다.
- success/error 페이로드를 `text`로 통일했습니다. 다만 `getMessageText`가 `text`와 `message`를 함께 읽으므로 어느 쪽으로 보내든 사유가 표시됩니다.
- `selectOutputPath`·`getWorkspacePath`·`getEgovSettings` 응답은 요청에 실린 `scope`를 그대로 되돌려주어, 요청한 탭에만 응답이 갑니다.
- `ProjectsView`에 `projects` 스코프 error 처리를 넣었습니다. 종전에는 프로젝트 템플릿 로드가 실패해도 받는 쪽이 없어 로딩 스피너만 계속 돌았습니다. 이제 로딩을 끝내고 목록 자리에 사유를 표시합니다. 안내 문구용 `projects.failedToLoadTemplates` 키를 ko/en 로케일에 추가했습니다.

### 스코프 없는 메시지는 종전대로 모든 탭이 처리합니다

`isMessageForScope`는 `scope`가 `undefined`이면 참을 반환합니다(`src/shared/webviewMessageRouting.ts`). 스코프를 싣지 않는 기존 발신 경로를 그대로 살리기 위한 하위호환 판정입니다.

`src/extension.ts`의 `currentWorkspacePath`가 그 예입니다. 특정 탭의 요청에 답하는 메시지가 아니라 열려 있는 모든 탭에 기본 출력 경로를 알리는 브로드캐스트라서 의도적으로 스코프를 붙이지 않았습니다. 코드에도 그 이유를 주석으로 남겼습니다. 요청 메시지의 `scope`, zod 스키마, `ExtensionMessage`의 `scope`는 모두 선택 필드이며 기존 `message` 필드도 그대로 두었습니다.

### `setIsLoading(false)` 호출 위치를 옮겼습니다

기존 `CodeView`는 메시지 핸들러에 들어오자마자 무조건 `setIsLoading(false)`를 호출했습니다. `currentTheme`·`sampleDDLs`처럼 코드 생성과 무관한 메시지가 도착해도 생성 중 스피너가 풀렸습니다. 스코프를 도입하면 다른 탭 응답까지 스피너를 건드리게 되므로 해제 호출을 `code` 스코프 success/error 분기 안으로 옮겼습니다.

스피너를 켜는 지점은 `handleGenerateCode`와 `handleUploadTemplates` 둘뿐입니다. 두 경로 모두 익스텐션이 `code` 스코프 응답을 반드시 보내므로 해제가 누락되지 않습니다.

## 테스트 방법

`npm run check-types`·`npm run lint`·`npm run format` 통과, `npm run build:webview`도 1100 모듈로 정상 빌드됩니다.

루트 vitest 41건(기존 34 + 신규 7)

- `src/shared/webviewMessageRouting.test.ts`: 스코프 일치·불일치·미지정 판정과 `text`/`message` 읽기 순서를 검증합니다.
- `src/shared/webviewMessageSchema.test.ts`: 요청 메시지의 선택 필드 `scope` 파싱을 검증합니다.

webview-ui vitest 133건(기존 127 + 신규 6)

- `CodeView.spec.tsx`: `code` 스코프 error의 사유가 그대로 표시되는지, 다른 탭 error는 표시되지 않는지 검증합니다.
- `ConfigView.spec.tsx`: `code` 스코프 error에는 오류 화면으로 전환하지 않고 `config` 스코프 error에는 실제 사유를 표시하는지 검증합니다.
- `ProjectsView.spec.tsx`: 다른 탭의 `selectedOutputPath`를 무시하는지, `projects` 스코프 error가 템플릿 로딩을 끝내고 사유를 표시하는지 검증합니다.

`isMessageForScope`를 항상 참을 반환하도록 되돌리고 `ProjectsView`의 error 처리를 제거하면 신규 6케이스 중 4건이 실패합니다.

테스트 환경 변경이 한 줄 있습니다. `webview-ui/vite.config.ts`의 `test.alias`에 `monaco-editor`를 빈 스텁으로 매핑했습니다. monaco-editor 0.31의 package.json에 `main` 필드가 없어 Vitest 해석 단계에서 실패하기 때문입니다. `test` 키 아래라 프로덕션 번들에는 영향이 없습니다.

## 영향 범위

익스텐션에서 웹뷰로 가는 메시지에 선택 필드가 하나 늘었을 뿐, 기존 메시지 형태는 유지됩니다. 스코프가 없는 메시지의 동작도 이전과 같습니다.

범위 밖으로 남긴 것이 둘 있습니다. `ConfigView`는 `config` 스코프 오류를 아직 오퍼레이션 단위로 구분하지 않아서 설정 파일 생성 실패도 템플릿 로드 실패와 같은 오류 화면으로 표시됩니다. 설정 화면의 초기 로드 실패가 로딩 화면에 가려지는 문제도 이번 변경 이전부터 있던 동작입니다. 둘 다 기존 동작 그대로 두었습니다. 이번 변경은 탭 사이의 교차 반응만 제거합니다.

CHANGELOG는 `## Unreleased`의 Code Generation 항목에 한 줄 추가했습니다.

