### PR TITLE
fix: Java 패키지명·groupId 검증이 연속된 점과 숫자로 시작하는 세그먼트를 통과시키는 문제 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - COMMENT·DEFAULT 문자열 안의 콤마·괄호 때문에 컬럼 분리가 깨져 DDL 파싱과 CRUD 코드 생성이 실패하던 문제 수정 (Refs: PR #34)
   - 생성된 MyBatis Mapper의 LIKE 검색이 문자열 결합에 `||`를 사용해 MySQL 기본 설정(PIPES_AS_CONCAT 미적용)에서 검색 조건이 무시되고 검색어와 무관하게 전체 행이 반환되던 문제 수정 — 방언 중립인 `<bind>`로 교체 (Refs: PR #35)
   - 코드 생성 실패 사유가 "알 수 없는 오류"로 대체되던 문제 수정 — 익스텐션 → 웹뷰 응답에 탭 스코프를 부여하고 실패 사유 페이로드를 text로 통일. 다른 탭의 실패가 Config 탭 오류 화면이나 Output Path 덮어쓰기로 번지지 않고, 프로젝트 템플릿 로드 실패는 Projects 탭에 표시된다 (Refs: PR #36)
+  - Java 패키지명과 groupId 검증을 통일해 연속된 점과 숫자로 시작하는 세그먼트를 거부하도록 수정 (Refs: PR #37)
 - Config Generation
   - AOP 트랜잭션 설정 템플릿에서 txAdvisor의 잘못된 직접 메서드 호출 수정 (Refs: PR #12)
   - TransactionForm의 READ_UNCOMMITTED 오타 수정 (Refs: PR #9)

--- a/src/shared/webviewMessageSchema.test.ts
+++ b/src/shared/webviewMessageSchema.test.ts
@@ -207,10 +207,8 @@ describe("parseWebviewMessage", () => {
 			const base = { type: "generateCode", ddl: "CREATE TABLE t (id INT)", outputPath: "/tmp/out" }
 			parseOk({ ...base, packageName: "com.example.sample" })
 			parseOk(base) // packageName 생략 가능
-			// 웹뷰 validateCodeConfig와 동일한 패턴이라 연속된 점은 통과하지만,
-			// codeGenerator의 createPackagePath가 점을 모두 슬래시로 바꾸므로 ..으로는 디렉터리 탈출이 불가능하다
-			parseOk({ ...base, packageName: "com..example" })
-			for (const packageName of ["../etc", "Com.Bad", "com.", ".com", "com/example"]) {
+			// 웹뷰 validateCodeConfig와 동일하게 연속된 점과 숫자로 시작하는 세그먼트를 거부한다
+			for (const packageName of ["../etc", "Com.Bad", "com.", ".com", "com/example", "com..example", "com.1example"]) {
 				parseFail({ ...base, packageName })
 			}
 		})

--- a/src/shared/webviewMessageSchema.ts
+++ b/src/shared/webviewMessageSchema.ts
@@ -21,8 +21,8 @@ const SAFE_ZIP_FILE_PATTERN = /^(?!\.)(?!.*\.\.)[A-Za-z0-9._-]+\.zip$/
 const SAFE_XML_FILE_PATTERN = /^(?!\.)(?!.*\.\.)[A-Za-z0-9._-]+\.xml$/
 const SAFE_HBS_FILE_PATTERN = /^(?!\.)(?!.*\.\.)[A-Za-z0-9._-]+\.hbs$/
 const TEMPLATE_FOLDER_PATTERN = /^[A-Za-z0-9_-]+$/
-// 웹뷰 validateCodeConfig와 동일한 Java 패키지명 규칙 — 패키지 경로(디렉터리) 생성에 쓰이므로 엄격하게 검증한다
-const JAVA_PACKAGE_PATTERN = /^[a-z]([a-z0-9.]*[a-z0-9])?$/
+// 웹뷰 validateCodeConfig와 동일한 Java 패키지명 규칙 — 점으로 구분된 각 세그먼트가 소문자로 시작해야 한다
+const JAVA_PACKAGE_PATTERN = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/
 
 // templates-context-xml.json은 "변형 템플릿 없음"을 빈 문자열로 표기하므로 빈 문자열도 허용한다
 const optionalHbsFileSchema = z.literal("").or(z.string().regex(SAFE_HBS_FILE_PATTERN)).optional()

--- a/src/utils/codeGenerator.ts
+++ b/src/utils/codeGenerator.ts
@@ -229,8 +229,8 @@ export async function generateCrudFromDDL(
 				prompt: "Enter package name (e.g., com.example.project)",
 				value: "com.example.project",
 				validateInput: (value) => {
-					if (!value || !value.includes(".")) {
-						return "Please enter a valid package name (e.g., com.example.project)"
+					if (!value || !/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(value)) {
+						return "Please enter a valid package name with dot-separated lowercase segments (e.g., com.example.project)"
 					}
 					return null
 				},

--- a/webview-ui/src/utils/__tests__/codeUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/codeUtils.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import { validateCodeConfig, validatePackageName } from "../codeUtils"
+
+describe("validateCodeConfig", () => {
+	const validConfig = {
+		packageName: "egovframework.example",
+		outputPath: "/tmp/out",
+	}
+
+	it("패키지명이 점으로 구분된 Java 패키지 규칙을 지키면 통과한다", () => {
+		for (const packageName of ["egovframework.example", "com.egov.app", "com", "egovframework.example.sample", "a1.b2c3"]) {
+			const errors = validateCodeConfig({ ...validConfig, packageName })
+			expect(errors, `expected no packageName error for "${packageName}"`).toHaveLength(0)
+		}
+	})
+
+	it("연속된 점과 숫자로 시작하는 세그먼트는 거부한다", () => {
+		for (const packageName of ["com..example", "com.1example"]) {
+			const errors = validateCodeConfig({ ...validConfig, packageName })
+			expect(errors).toContain(
+				"Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
+			)
+		}
+	})
+
+	it("기존에 잘못된 패키지명도 계속 거부한다", () => {
+		for (const packageName of ["com.", ".com", "Com.Example"]) {
+			const errors = validateCodeConfig({ ...validConfig, packageName })
+			expect(errors).toContain(
+				"Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
+			)
+		}
+	})
+
+	it("패키지명이 없거나 공백이면 필수 오류를 반환한다", () => {
+		for (const packageName of ["", "   "]) {
+			const errors = validateCodeConfig({ ...validConfig, packageName })
+			expect(errors).toContain("Package name is required")
+		}
+	})
+
+	it("outputPath가 없으면 필수 오류를 반환한다", () => {
+		const errors = validateCodeConfig({ packageName: "com.example" })
+		expect(errors).toContain("Output path is required")
+	})
+})
+
+describe("validatePackageName", () => {
+	it("패키지명이 점으로 구분된 Java 패키지 규칙을 지키면 null을 반환한다", () => {
+		for (const packageName of ["egovframework.example", "com.egov.app", "com", "egovframework.example.sample", "a1.b2c3"]) {
+			expect(validatePackageName(packageName), `expected no packageName error for "${packageName}"`).toBeNull()
+		}
+	})
+
+	it("연속된 점과 숫자로 시작하는 세그먼트는 거부한다", () => {
+		for (const packageName of ["com..example", "com.1example"]) {
+			expect(validatePackageName(packageName)).toBe(
+				"Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
+			)
+		}
+	})
+
+	it("기존에 잘못된 패키지명도 계속 거부한다", () => {
+		for (const packageName of ["com.", ".com", "Com.Example"]) {
+			expect(validatePackageName(packageName)).toBe(
+				"Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
+			)
+		}
+	})
+
+	it("패키지명이 없거나 공백이면 필수 오류를 반환한다", () => {
+		for (const packageName of ["", "   "]) {
+			expect(validatePackageName(packageName)).toBe("Package name is required")
+		}
+	})
+})

--- a/webview-ui/src/utils/__tests__/settingsUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/settingsUtils.spec.ts
@@ -56,6 +56,17 @@ describe("validateEgovSettings", () => {
 		expect(errors.some((e) => e.includes("Default Group ID must start"))).toBe(true)
 	})
 
+	it("defaultGroupId가 연속된 점이나 숫자로 시작하는 세그먼트를 포함하면 오류를 반환한다", () => {
+		for (const defaultGroupId of ["com..example", "com.1example"]) {
+			const errors = validateEgovSettings({
+				defaultGroupId,
+				defaultArtifactId: "my-project",
+				defaultPackageName: "egovframework.example",
+			})
+			expect(errors.some((e) => e.includes("Default Group ID must start"))).toBe(true)
+		}
+	})
+
 	it("defaultArtifactId가 없으면 오류를 반환한다", () => {
 		const errors = validateEgovSettings({
 			defaultGroupId: "egovframework.com",
@@ -99,6 +110,17 @@ describe("validateEgovSettings", () => {
 			defaultPackageName: "egovframework.example.",
 		})
 		expect(errors.some((e) => e.includes("Default Package Name must start"))).toBe(true)
+	})
+
+	it("defaultPackageName이 연속된 점이나 숫자로 시작하는 세그먼트를 포함하면 오류를 반환한다", () => {
+		for (const defaultPackageName of ["com..example", "com.1example"]) {
+			const errors = validateEgovSettings({
+				defaultGroupId: "egovframework.com",
+				defaultArtifactId: "my-project",
+				defaultPackageName,
+			})
+			expect(errors.some((e) => e.includes("Default Package Name must start"))).toBe(true)
+		}
 	})
 
 	it("여러 필드가 동시에 잘못되면 모든 오류를 반환한다", () => {

--- a/webview-ui/src/utils/codeUtils.ts
+++ b/webview-ui/src/utils/codeUtils.ts
@@ -7,16 +7,16 @@ export interface CodeConfig {
 
 /**
  * CodeView에서 사용되는 설정에 대한 validation을 수행합니다.
- * packageName은 Java package name 규칙을 따르며 groupId와 동일한 validation을 적용합니다.
+ * packageName은 점으로 구분된 각 세그먼트가 소문자로 시작하는 Java package name 규칙을 따릅니다.
  */
 export function validateCodeConfig(config: Partial<CodeConfig>): string[] {
 	const errors: string[] = []
 
 	if (!config.packageName || config.packageName.trim() === "") {
 		errors.push("Package name is required")
-	} else if (!/^[a-z]([a-z0-9.]*[a-z0-9])?$/.test(config.packageName)) {
+	} else if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(config.packageName)) {
 		errors.push(
-			"Package name must start with a lowercase letter, contain only lowercase letters, numbers, or dots, and cannot end with a dot",
+			"Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
 		)
 	}
 
@@ -39,7 +39,7 @@ export function hasSpecialCharacters(value: string): boolean {
 
 /**
  * Java 패키지명 유효성을 검사합니다.
- * 패키지명은 소문자로 시작하고, 소문자, 숫자, 점(.)만 포함할 수 있으며, 점으로 끝날 수 없습니다.
+ * 패키지명은 점으로 구분된 각 세그먼트가 소문자로 시작하고, 소문자와 숫자만 포함할 수 있습니다.
  * @param packageName - 검사할 패키지명
  * @returns 에러 메시지 (유효하면 null)
  */
@@ -48,8 +48,8 @@ export function validatePackageName(packageName: string): string | null {
 		return "Package name is required"
 	}
 
-	if (!/^[a-z]([a-z0-9.]*[a-z0-9])?$/.test(packageName)) {
-		return "Package name must start with a lowercase letter, contain only lowercase letters, numbers, or dots, and cannot end with a dot"
+	if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(packageName)) {
+		return "Package name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers"
 	}
 
 	return null

--- a/webview-ui/src/utils/settingsUtils.ts
+++ b/webview-ui/src/utils/settingsUtils.ts
@@ -6,7 +6,7 @@ export interface EgovSettings {
 
 /**
  * EgovSettings에 대한 validation을 수행합니다.
- * groupId, artifactId, packageName은 기존 projectUtils.ts와 codeUtils.ts의 validation 규칙을 따릅니다.
+ * groupId와 packageName은 점으로 구분된 각 세그먼트가 소문자로 시작하는 규칙을 따릅니다.
  */
 export function validateEgovSettings(settings: Partial<EgovSettings>): string[] {
 	const errors: string[] = []
@@ -14,9 +14,9 @@ export function validateEgovSettings(settings: Partial<EgovSettings>): string[] 
 	// defaultGroupId validation
 	if (!settings.defaultGroupId || settings.defaultGroupId.trim() === "") {
 		errors.push("Default Group ID is required")
-	} else if (!/^[a-z]([a-z0-9.]*[a-z0-9])?$/.test(settings.defaultGroupId)) {
+	} else if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(settings.defaultGroupId)) {
 		errors.push(
-			"Default Group ID must start with a lowercase letter, contain only lowercase letters, numbers, or dots, and cannot end with a dot",
+			"Default Group ID must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
 		)
 	}
 
@@ -32,9 +32,9 @@ export function validateEgovSettings(settings: Partial<EgovSettings>): string[] 
 	// defaultPackageName validation
 	if (!settings.defaultPackageName || settings.defaultPackageName.trim() === "") {
 		errors.push("Default Package Name is required")
-	} else if (!/^[a-z]([a-z0-9.]*[a-z0-9])?$/.test(settings.defaultPackageName)) {
+	} else if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(settings.defaultPackageName)) {
 		errors.push(
-			"Default Package Name must start with a lowercase letter, contain only lowercase letters, numbers, or dots, and cannot end with a dot",
+			"Default Package Name must start with a lowercase letter and consist of dot-separated segments, where each segment starts with a lowercase letter and contains only lowercase letters or numbers",
 		)
 	}
 


### PR DESCRIPTION
## 변경 이유

Java 패키지명·groupId 검증이 코드베이스 안에서 두 갈래로 갈려 있습니다.

`webview-ui/src/utils/projectUtils.ts` 72행은 세그먼트 단위로 검사합니다.

```ts
/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/
```

나머지 다섯 곳은 문자 집합만 검사합니다.

```ts
/^[a-z]([a-z0-9.]*[a-z0-9])?$/
```

뒤쪽 정규식은 점의 위치를 보지 않기 때문에 `com..example`과 `com.1example`을 통과시킵니다. 둘 다 Java 패키지명이 아닙니다. 연속된 점은 빈 세그먼트이고, 숫자로 시작하는 세그먼트는 Java 식별자 규칙 위반입니다.

통과한 값은 그대로 코드 생성에 쓰입니다. `codeGenerator.ts` 117~119행의 `createPackagePath`가 점을 슬래시로 바꾸므로 `com..example`은 `com//example`이 되고, 생성된 소스에는 `package com..example;`이 그대로 적힙니다. 컴파일되지 않는 파일이 만들어집니다. `com.1example`도 마찬가지입니다.

`src/utils/codeGenerator.ts` 229~235행의 입력 프롬프트는 더 느슨해서 점이 하나라도 있으면 통과시킵니다.

```ts
if (!value || !value.includes(".")) {
```

`..`, `a..b`, `A.B` 모두 통과합니다.

## 변경 내용

- 나머지 다섯 곳의 정규식을 `projectUtils.ts`가 쓰는 세그먼트 기반 패턴으로 통일했습니다. 대상은 `webview-ui/src/utils/codeUtils.ts`(2곳), `webview-ui/src/utils/settingsUtils.ts`(2곳), `src/shared/webviewMessageSchema.ts`(1곳)입니다.
- `src/utils/codeGenerator.ts`의 프롬프트 검증도 같은 패턴으로 교체했습니다.
- 새 규칙을 설명하도록 오류 메시지를 고쳤습니다. 기존 문구는 "점으로 끝날 수 없다"까지만 안내해 연속된 점이 왜 거부되는지 알 수 없습니다.
- 테스트를 추가했습니다. `codeUtils.spec.ts`에 `validateCodeConfig`·`validatePackageName` 각각의 허용·거부 케이스, `settingsUtils.spec.ts`에 `defaultGroupId`·`defaultPackageName` 거부 케이스입니다. `webviewMessageSchema.test.ts`는 `com..example`을 통과 기대값으로 두고 있어 거부 기대값으로 옮겼습니다.

## 테스트 방법

```
npm run compile
cd webview-ui && npm run build && npm test
```

`npm run compile`(tsc --noEmit + eslint)과 웹뷰 프로덕션 빌드가 통과하고, 웹뷰 테스트 10개 파일 138건이 모두 통과합니다. main 기준 127건에서 11건 늘었습니다.

## 영향 범위

- 수정 파일은 검증 로직 4개, 테스트 3개, CHANGELOG입니다.
- `com..example`·`com.1example`처럼 지금까지 통과하던 입력이 거부됩니다. 이들로 생성한 결과물은 컴파일되지 않으므로 실제로 쓰이던 값은 아니라고 봅니다.
- `codeGenerator.ts` 프롬프트에서는 점이 없는 `com` 같은 단일 세그먼트가 허용 쪽으로 바뀝니다. 나머지 다섯 곳이 이미 허용하던 값이고 Java에서도 유효한 패키지명이라 통일 대상에 포함했습니다.
- 설정 키, 공개 API, 의존성 변경은 없습니다.
